### PR TITLE
Implement core gameplay loop

### DIFF
--- a/.trace/architect.md
+++ b/.trace/architect.md
@@ -49,3 +49,50 @@ If resuming this agent from branch state:
 ## Completion
 - Final commit pushed: `39d6767`
 - Subtask issue #4 closed after artifact publication.
+
+---
+
+## Phase
+Issue #10 architecture design
+
+## Timestamp
+2026-03-11T21:03:00Z
+
+## Input
+- Issue: #10
+- Trigger: Approved spec handoff on branch `feature/issue-10`
+- Key artifacts read: GitHub issue #10, `docs/knowledge/architecture.md`, `docs/knowledge/stack.md`, `src/server/index.ts`, `src/server/roomService.ts`, `src/shared/contracts.ts`
+
+## Decisions
+1. Decision: Keep gameplay under the existing in-memory `RoomService` orchestration boundary with a per-room gameplay runtime.
+   Rationale: Fits the current codebase, preserves single-instance simplicity, and keeps countdown/tick timers isolated per room.
+2. Decision: Use a fixed deterministic tick resolution order with simultaneous collision evaluation.
+   Rationale: Required to make head-to-head, cross-over, food, and death outcomes unambiguous and reproducible.
+3. Decision: Use one queued direction slot per snake and validate reversals against the effective upcoming direction.
+   Rationale: Handles just-before-tick inputs without allowing reversal exploits or unbounded buffering.
+4. Decision: End the room with a short result window followed by forced teardown.
+   Rationale: Matches the approved requirement that players must create/join a fresh room after a round completes.
+
+## Actions Taken
+1. Prepared dedicated architect checkout on `feature/issue-10` and verified branch alignment → working branch ready.
+2. Read parent issue #10 and current lobby/server contracts → baseline architecture constraints confirmed.
+3. Added `in-design` label to parent issue #10 and created linked architecture subtask issue #11 → GitHub tracking in place.
+4. Wrote `docs/impl/core-gameplay-loop/design.md` → authoritative gameplay lifecycle, collision order, countdown, speed, teardown, and implementation sequence documented.
+5. Wrote `docs/impl/core-gameplay-loop/api-contracts.md` → recommended Socket.IO event and payload extensions documented.
+
+## Outputs
+- `docs/impl/core-gameplay-loop/design.md`: gameplay architecture, tick loop, collision resolution, countdown, speed progression, teardown
+- `docs/impl/core-gameplay-loop/api-contracts.md`: socket contracts for direction input, countdown, state snapshots, round end, room close
+- `.trace/architect.md`: resume and audit trace for issue #10
+
+## Handoff
+- Next agent: fullstack-dev
+- Trigger: PM checks off Architecture design and hands off development
+- Context needed: Read issue #10, issue #11, `docs/impl/core-gameplay-loop/design.md`, `docs/impl/core-gameplay-loop/api-contracts.md`, and current lobby code in `src/server/roomService.ts` and `src/shared/contracts.ts`
+
+## Resume Point
+If resuming this agent from branch state:
+- Read this trace file first.
+- Check issue labels for current workflow state.
+- Read the latest PR comments for context.
+- Do NOT reload the full codebase — only files referenced in this trace.

--- a/.trace/fullstack-dev.md
+++ b/.trace/fullstack-dev.md
@@ -1,0 +1,46 @@
+# Fullstack Developer Trace
+
+## Phase
+Issue #10 — build/version marker implementation
+
+## Timestamp
+2026-03-11T23:37:30Z
+
+## Input
+- Issue: #10
+- Trigger: PM handoff for visible deployment/build marker on `feature/issue-10`
+- Key artifacts read: `public/index.html`, `public/app.js`, `public/styles.css`, `src/server/index.ts`, `package.json`, `docs/impl/room-lobby-autostart/dev-notes.md`, PR #12 metadata
+
+## Decisions
+1. Decision: Surface the version as a small UI pill in the main panel header.
+   Rationale: Keeps it always visible during review without distracting from the lobby workflow.
+2. Decision: Source the marker from server-exposed build metadata (`package.json` version + short git SHA).
+   Rationale: The commit hash changes with each deployable code change and is easy for reviewers to compare across deployments.
+3. Decision: Fetch build metadata with `no-store` semantics.
+   Rationale: Helps distinguish browser caching from actual deployment lag.
+
+## Actions Taken
+1. Added `/build-info.json` handling in the Node server and startup build-info resolution → app can expose deploy identity without changing gameplay.
+2. Added a visible `Build: ...` marker and tooltip in the lobby UI → reviewers can inspect deployment freshness at a glance.
+3. Updated implementation notes under `docs/impl/room-lobby-autostart/dev-notes.md` and created `docs/impl/core-gameplay-loop/dev-notes.md` for the requested issue path → documentation aligned with the handoff.
+4. Ran validation (`npm ci`, `npx vitest run`, `npm run build`) → checks passed.
+
+## Outputs
+- `src/server/index.ts`: exposes build metadata and disables caching for metadata/index responses.
+- `public/index.html`: adds visible build marker container.
+- `public/app.js`: fetches and renders build metadata.
+- `public/styles.css`: styles the build marker.
+- `docs/impl/room-lobby-autostart/dev-notes.md`: notes implementation approach.
+- `docs/impl/core-gameplay-loop/dev-notes.md`: requested dev-notes artifact for issue #10.
+
+## Handoff
+- Next agent: code-reviewer
+- Trigger: development complete / PR update
+- Context needed: review the build marker UI placement, `/build-info.json` implementation, and cache-busting behavior on `feature/issue-10`.
+
+## Resume Point
+If resuming this agent from branch state:
+- Read this trace file first.
+- Inspect `src/server/index.ts`, `public/app.js`, and `docs/impl/core-gameplay-loop/dev-notes.md`.
+- Verify checks with `npm ci`, `npx vitest run`, and `npm run build`.
+- Confirm PR #12 still targets `feature/issue-10`.

--- a/.trace/fullstack-dev.md
+++ b/.trace/fullstack-dev.md
@@ -44,3 +44,47 @@ If resuming this agent from branch state:
 - Inspect `src/server/index.ts`, `public/app.js`, and `docs/impl/core-gameplay-loop/dev-notes.md`.
 - Verify checks with `npm ci`, `npx vitest run`, and `npm run build`.
 - Confirm PR #12 still targets `feature/issue-10`.
+
+
+## Phase
+Issue #10 follow-up gameplay UI cleanup
+
+## Timestamp
+2026-03-11T23:52:20Z
+
+## Input
+- Issue: #10
+- Trigger: stakeholder follow-up on PR #12 / branch feature/issue-10
+- Key artifacts read: public/index.html, public/app.js, public/styles.css, docs/impl/core-gameplay-loop/dev-notes.md, task skill notes
+
+## Decisions
+1. Decision: hide the global title/subtitle shell and top status banner during gameplay states.
+   Rationale: stakeholder explicitly reported those top elements still appeared above the board, so board-first layout was not strict enough.
+2. Decision: keep only compact gameplay info in side rails and duplicate the build marker into the gameplay rail.
+   Rationale: preserves essential room/match/debug info without reintroducing top chrome above the board.
+3. Decision: install dependencies before running repo validation in a fresh checkout.
+   Rationale: npm test failed initially because local Vitest binaries were unavailable until npm ci ran.
+
+## Actions Taken
+1. Rebased the checkout onto origin/feature/issue-10 and inspected current gameplay layout → confirmed board-first attempt still left header/status above gameplay.
+2. Updated public/index.html / public/app.js / public/styles.css → gameplay now hides top shell + status, moves inline match status into the left rail, keeps room code/countdown/speed/player scores in side rails, and shows the build marker inside gameplay.
+3. Updated docs/impl/core-gameplay-loop/dev-notes.md → documented the follow-up cleanup.
+4. Ran npm ci, npm test, and npm run build → all passed.
+
+## Outputs
+- public/index.html: removed gameplay dependence on top chrome; added inline gameplay status + gameplay build marker.
+- public/app.js: synced gameplay-only visibility, mirrored the build marker, and routed gameplay status copy into the side rail.
+- public/styles.css: tightened the board-first layout so the board occupies the first/top gameplay row with side-mounted support cards.
+- docs/impl/core-gameplay-loop/dev-notes.md: added follow-up UI cleanup notes.
+
+## Handoff
+- Next agent: code-reviewer / PM
+- Trigger: dev handoff on updated PR #12
+- Context needed: review the gameplay screen in the updated branch and confirm the board is the first visible primary content during countdown, in-progress, and game-over.
+
+## Resume Point
+If resuming this agent from branch state:
+- Read this trace file first.
+- Check PR #12 and issue #10 for the latest stakeholder feedback.
+- Inspect public/index.html, public/app.js, public/styles.css, and docs/impl/core-gameplay-loop/dev-notes.md only.
+- Re-run npm ci before validation if the checkout is fresh.

--- a/docs/impl/core-gameplay-loop/api-contracts.md
+++ b/docs/impl/core-gameplay-loop/api-contracts.md
@@ -1,0 +1,288 @@
+# Core Gameplay Loop Socket Contracts
+
+## Purpose
+This document defines the recommended Socket.IO contract additions for the core gameplay loop feature.
+
+The current repo already has lobby-level contracts for room creation/join/ready flow. This feature should extend those contracts rather than inventing a second transport model.
+
+## Contract Design Principles
+- server authoritative for countdown, movement, collisions, score, and result
+- client sends intent only
+- all payloads scoped to one room
+- snapshots contain enough data for thin clients to render the board without local simulation
+- terminal result is explicit and never inferred by the client
+
+## Shared Types
+
+```ts
+type RoomPhase =
+  | 'waiting-for-players'
+  | 'lobby'
+  | 'starting'
+  | 'in-progress'
+  | 'game-over';
+
+type Direction = 'up' | 'down' | 'left' | 'right';
+
+type RoundResult = 'win' | 'lose' | 'draw';
+
+type DeathReason = 'wall' | 'self' | 'head-to-head' | 'head-to-body' | 'cross-over' | 'disconnect';
+
+interface GridPoint {
+  x: number;
+  y: number;
+}
+
+interface PublicSnakeState {
+  slotIndex: 0 | 1;
+  body: GridPoint[];
+  direction: Direction;
+  alive: boolean;
+  score: number;
+}
+
+interface PublicGameStatePayload {
+  roomCode: string;
+  phase: 'starting' | 'in-progress' | 'game-over';
+  tickNumber: number;
+  board: {
+    width: 30;
+    height: 30;
+  };
+  food: GridPoint;
+  snakes: [PublicSnakeState, PublicSnakeState];
+  foodsEaten: number;
+  tickIntervalMs: number;
+  countdownSecondsRemaining?: 3 | 2 | 1 | 0;
+  result?: {
+    outcome: RoundResult;
+    winnerSlotIndex: 0 | 1 | null;
+    deathReasons: Array<{ slotIndex: 0 | 1; reason: DeathReason }>;
+  };
+  version: number;
+}
+```
+
+## Client -> Server Events
+
+### `player:direction:set`
+Sent by a player to request a direction change during countdown or active gameplay.
+
+```ts
+interface PlayerDirectionSetPayload {
+  direction: Direction;
+}
+```
+
+Validation rules:
+- socket must belong to a player in the room
+- room phase must be `starting` or `in-progress`
+- direction must be one of `up/down/left/right`
+- immediate reversal is rejected
+- server stores at most one pending direction per snake
+
+Behavior notes:
+- allowed during countdown so the opening move can be queued
+- applied on the next authoritative tick after gameplay starts
+- no acknowledgement is required for success if snapshots are frequent, but invalid inputs should emit `room:error` with `ACTION_NOT_ALLOWED` or a gameplay-specific error if the implementation adds one
+
+## Server -> Client Events
+
+### `game:countdown`
+Broadcast to both players whenever the pre-game countdown changes.
+
+```ts
+interface GameCountdownPayload {
+  roomCode: string;
+  phase: 'starting';
+  secondsRemaining: 3 | 2 | 1 | 0;
+  startsAt: number;
+  serverNow: number;
+  version: number;
+}
+```
+
+Usage:
+- client renders visible 3-second pre-game countdown
+- snakes remain stationary while this event sequence is in progress
+
+### `game:start`
+Broadcast once when countdown completes and active play begins.
+
+```ts
+interface GameStartPayload {
+  roomCode: string;
+  phase: 'in-progress';
+  board: {
+    width: 30;
+    height: 30;
+  };
+  players: [
+    { slotIndex: 0; label: 'Player 1' },
+    { slotIndex: 1; label: 'Player 2' }
+  ];
+  tickIntervalMs: number;
+  startedAt: number;
+  version: number;
+}
+```
+
+Notes:
+- the existing `game:start` event can be expanded rather than replaced
+- this event should not fire until movement is actually about to begin
+
+### `game:state`
+Broadcast after every authoritative gameplay tick and also optionally once at countdown initialization so clients can render the board before movement.
+
+```ts
+type GameStatePayload = PublicGameStatePayload;
+```
+
+Minimum expectations:
+- contains full snake bodies for both players
+- contains current food position
+- contains scores and alive flags
+- contains current `tickIntervalMs`
+- contains `tickNumber` for client debugging/reconciliation
+
+### `game:ended`
+Broadcast once when the round reaches a terminal outcome.
+
+```ts
+interface GameEndedPayload {
+  roomCode: string;
+  phase: 'game-over';
+  result: {
+    bySlot: {
+      0: 'win' | 'lose' | 'draw';
+      1: 'win' | 'lose' | 'draw';
+    };
+    winnerSlotIndex: 0 | 1 | null;
+    deathReasons: Array<{ slotIndex: 0 | 1; reason: DeathReason }>;
+  };
+  finalState: PublicGameStatePayload;
+  teardownAt: number;
+  version: number;
+}
+```
+
+Why both `result` and `finalState`:
+- `result` gives a direct UX-ready outcome
+- `finalState` preserves the final board for rendering the result screen
+
+### `room:closed`
+Broadcast when the result display window is over and the room is torn down.
+
+```ts
+interface RoomClosedPayload {
+  roomCode: string;
+  reason: 'round-complete' | 'player-disconnected';
+  version: number;
+}
+```
+
+Client expectation:
+- clear local room/game state
+- return player to create/join entry flow
+- do not offer replay within the same room
+
+## Existing Event Compatibility
+The current shared contract contains:
+- `room:create`
+- `room:created`
+- `room:join`
+- `room:joined`
+- `room:error`
+- `lobby:state`
+- `player:ready:set`
+- `player:left`
+- `game:start`
+
+Recommended additions to `EVENTS`:
+
+```ts
+export const EVENTS = {
+  roomCreate: 'room:create',
+  roomCreated: 'room:created',
+  roomJoin: 'room:join',
+  roomJoined: 'room:joined',
+  roomError: 'room:error',
+  lobbyState: 'lobby:state',
+  playerReadySet: 'player:ready:set',
+  playerLeft: 'player:left',
+  playerDirectionSet: 'player:direction:set',
+  gameCountdown: 'game:countdown',
+  gameStart: 'game:start',
+  gameState: 'game:state',
+  gameEnded: 'game:ended',
+  roomClosed: 'room:closed',
+} as const;
+```
+
+## Phase Semantics
+
+### `starting`
+Means:
+- both players are present and ready
+- board state exists
+- 3-second countdown is visible
+- movement has not started yet
+
+### `in-progress`
+Means:
+- authoritative tick loop is running
+- direction input can change future movement
+- food, scores, and collision resolution are active
+
+### `game-over`
+Means:
+- round outcome has been resolved
+- gameplay has stopped
+- result is visible until teardown
+
+## Snapshot Frequency Guidance
+Recommended behavior:
+- emit `game:state` once immediately when countdown begins so clients can render spawn positions and food
+- emit `game:state` after every active gameplay tick
+- emit `game:ended` once at terminal transition
+
+If implementation wants fewer custom event handlers, it may also include enough information in `game:state` for countdown/result rendering, but `game:countdown` and `game:ended` remain recommended because they simplify client state transitions.
+
+## Error Handling Guidance
+The current `LobbyErrorReason` union is room/lobby-specific. For MVP, the dev agent can either:
+1. continue using `ACTION_NOT_ALLOWED` for invalid direction input, or
+2. extend error reasons with gameplay-specific variants such as `INVALID_DIRECTION`
+
+Recommendation:
+- keep MVP simple and reuse `ACTION_NOT_ALLOWED` unless UX clearly needs more precision
+
+## Example Round Timeline
+
+### Countdown start
+Server emits:
+1. `lobby:state` with `phase: 'starting'`
+2. `game:state` with initial board, food, scores, `countdownSecondsRemaining: 3`
+3. `game:countdown` with `secondsRemaining: 3`
+
+### Countdown progression
+Server emits:
+- `game:countdown` with `2`
+- `game:countdown` with `1`
+- `game:countdown` with `0`
+
+### Active round start
+Server emits:
+- `game:start`
+- `game:state` after first authoritative tick
+- subsequent `game:state` after each tick
+
+### Round end
+Server emits:
+- `game:ended` with result and final state
+- after result window, `room:closed`
+
+## Contract Notes for the Next Agent
+- Keep all payload types in `src/shared/contracts.ts` so both server and client can share them.
+- Preserve backward compatibility where reasonable, but treat `game:start` as expandable because the current payload is too small for gameplay.
+- Full board snapshots are acceptable for MVP; delta compression is unnecessary at this stage.
+- Include `version` or `tickNumber` in gameplay payloads to aid reconciliation and debugging.

--- a/docs/impl/core-gameplay-loop/deploy-log.md
+++ b/docs/impl/core-gameplay-loop/deploy-log.md
@@ -64,3 +64,41 @@ This confirms the deployed environment is serving both the app shell and the gam
 ## Notes
 - The first immediate localhost curl right after PM2 restart failed during process warm-up, but a follow-up check seconds later succeeded with the process stable and online.
 - No merge was performed.
+
+---
+
+## Dev refresh update
+- Refresh reason: stakeholder reported dev looked stale and did not reflect the latest lobby-hiding change
+- Previous deployed commit found on server checkout: `d9b11bb`
+- Refreshed deployed commit: `e7397cb` (`Hide lobby UI during active game states`)
+- Refreshed at (UTC): `2026-03-11 23:33`
+- Dev URL: `http://20.106.185.110:8081/`
+
+### Refresh actions
+```bash
+cd /home/rootagent/deployments/dev
+git fetch origin feature/issue-10
+git checkout feature/issue-10 || git checkout -b feature/issue-10 origin/feature/issue-10
+git reset --hard origin/feature/issue-10
+npm ci
+npm test
+npm run build
+pm2 startOrRestart /home/rootagent/deployments/ecosystem.config.js --only app-dev
+pm2 save
+```
+
+### Refresh validation
+- Server deployment checkout now resolves to `e7397cb7e3d038a849e7c71e2c91969aee88bde7`.
+- `npm test` passed: 2 test files / 10 tests.
+- `npm run build` passed.
+- `pm2 list` shows `app-dev` online after restart.
+- `curl -I http://127.0.0.1:3001/` returned `HTTP/1.1 200 OK` after warm-up.
+- `curl -I http://20.106.185.110:8081/` returned `HTTP/1.1 200 OK`.
+- Live `http://20.106.185.110:8081/app.js` now contains the updated gameplay-screen switch:
+  - `const gameplayFocused = state.phase === 'starting' || state.phase === 'in-progress' || state.phase === 'game-over';`
+  - `showScreen(gameplayFocused ? 'gameplay' : 'lobby');`
+
+### Caching / stale-asset conclusion
+- The stale behavior was caused by the dev server checkout itself still being on old commit `d9b11bb`, not by a mismatched feature-branch HEAD.
+- This app serves non-fingerprinted static assets such as `/app.js`, so browser caching can potentially confuse verification, but the server-side deploy target was definitively outdated before the refresh.
+- After resetting the dev checkout to `origin/feature/issue-10` and restarting PM2, the public dev URL served the updated client code from `e7397cb`.

--- a/docs/impl/core-gameplay-loop/deploy-log.md
+++ b/docs/impl/core-gameplay-loop/deploy-log.md
@@ -1,0 +1,66 @@
+# Dev deployment log — Core Gameplay Loop
+
+## Deployment target
+- Parent issue: `#10`
+- PR: `#12`
+- Branch: `feature/issue-10`
+- Feature slug: `core-gameplay-loop`
+- Environment: `dev`
+- Dev URL: `http://20.106.185.110:8081/`
+- Deployed commit: `d9b11bb`
+- Deployed at (UTC): `2026-03-11 22:54`
+
+## Deployment actions
+```bash
+cd /home/rootagent/deployments/dev
+git fetch origin feature/issue-10
+git checkout feature/issue-10 || git checkout -b feature/issue-10 origin/feature/issue-10
+git reset --hard origin/feature/issue-10
+npm ci
+npm run build
+pm2 startOrRestart /home/rootagent/deployments/ecosystem.config.js --only app-dev
+pm2 save
+```
+
+## Validation
+### Pre-deploy verification
+```bash
+npm ci
+npm test
+npm run build
+```
+
+Results:
+- `vitest`: 2 test files passed / 10 tests passed
+- TypeScript build completed successfully
+
+### Runtime health checks
+```bash
+pm2 list
+curl -I http://127.0.0.1:3001/
+curl -I http://20.106.185.110:8081/
+curl 'http://20.106.185.110:8081/socket.io/?EIO=4&transport=polling'
+```
+
+Results:
+- `app-dev` is `online` in PM2
+- local app on `127.0.0.1:3001` returned `HTTP/1.1 200 OK`
+- public dev URL returned `HTTP/1.1 200 OK` through nginx
+- Socket.IO polling handshake returned a valid session payload
+
+### Gameplay-path socket verification
+A two-client live socket check was run against the deployed dev URL to confirm the gameplay-relevant path beyond a bare handshake.
+
+Verified sequence:
+1. Player 1 created room `WTYZ`
+2. Player 2 joined the room
+3. Both players marked ready
+4. Server emitted countdown events `3 → 2 → 1 → 0`
+5. Server emitted `game:start` with authoritative tick interval
+6. Server emitted `game:state` with `phase: in-progress` and `tickNumber: 1`
+
+This confirms the deployed environment is serving both the app shell and the gameplay socket flow required to enter an active round.
+
+## Notes
+- The first immediate localhost curl right after PM2 restart failed during process warm-up, but a follow-up check seconds later succeeded with the process stable and online.
+- No merge was performed.

--- a/docs/impl/core-gameplay-loop/deploy-log.md
+++ b/docs/impl/core-gameplay-loop/deploy-log.md
@@ -102,3 +102,24 @@ pm2 save
 - The stale behavior was caused by the dev server checkout itself still being on old commit `d9b11bb`, not by a mismatched feature-branch HEAD.
 - This app serves non-fingerprinted static assets such as `/app.js`, so browser caching can potentially confuse verification, but the server-side deploy target was definitively outdated before the refresh.
 - After resetting the dev checkout to `origin/feature/issue-10` and restarting PM2, the public dev URL served the updated client code from `e7397cb`.
+
+---
+
+## Dev refresh update
+- Refresh reason: publish latest gameplay UI fixes together for stakeholder review
+- Refreshed deployed commit:   - full:                                                                 d006d267a1a8bd1665b533ccedb200fbedcda739
+  - short:     d006d26
+- Refreshed at (UTC):   2026-03-11 23:57
+- Dev URL:   http://20.106.185.110:8081/
+
+### Refresh validation
+- Dev deploy checkout reset to       origin/feature/issue-10 at   d006d26.
+-             npm test passed: 2 test files / 10 tests.
+- npm run build passed.
+- pm2 restart completed with               app-dev online.
+- Local health check on http://127.0.0.1:3001/ returned HTTP 200.
+- Public health check on http://20.106.185.110:8081/ returned HTTP 200.
+- Socket.IO polling handshake succeeded on /socket.io/.
+- Live /build-info.json returned:       {"version":"0.1.0","commit":"d006d26","builtAt":"2026-03-11T23:56:25.465Z","displayVersion":"v0.1.0+d006d26"}
+- Live /app.js contains gameplay-focused screen switching:   yes
+- Live /app.js contains transient message helper:   no

--- a/docs/impl/core-gameplay-loop/design.md
+++ b/docs/impl/core-gameplay-loop/design.md
@@ -1,0 +1,462 @@
+# Core Gameplay Loop Architecture
+
+## Scope
+This design extends the existing 2-player room lobby into a complete authoritative Snake round for issue #10.
+
+It focuses on:
+- authoritative server tick loop
+- 3-second countdown state
+- deterministic movement and collision resolution
+- shared food spawning and score/length growth
+- global speed progression
+- round-end result publication
+- room teardown after a short result display window
+
+This document does **not** implement code. It defines the server state model, update order, and integration points for the next agent.
+
+## Current Baseline
+The repository already provides:
+- in-memory `RoomService`
+- room create/join/ready flow
+- `waiting-for-players` / `lobby` / `starting` / `in-progress` room phases
+- Socket.IO transport with shared event constants in `src/shared/contracts.ts`
+
+The current `starting` phase is effectively instantaneous. For this feature, `starting` becomes a real countdown phase and `in-progress` becomes a full active match state.
+
+## Architectural Goals
+1. Keep gameplay fully server-authoritative.
+2. Make every round resolution deterministic.
+3. Preserve simple single-instance in-memory architecture.
+4. Keep the client thin: input + rendering only.
+5. Support exactly 2 anonymous players.
+6. Tear down the completed room after result visibility instead of returning to a reusable lobby.
+
+## Recommended Module Boundaries
+
+### 1. `RoomService` remains the orchestration boundary
+`RoomService` should continue owning:
+- room lifecycle
+- socket-to-room mapping
+- ready state and disconnect handling
+- countdown start triggers
+- creation/destruction of per-room gameplay runtime
+- broadcast of room/game events
+
+### 2. Add a gameplay runtime/controller per active room
+Recommended new server-side unit:
+- `GameRuntime` or `MatchRuntime`
+
+Responsibilities:
+- hold gameplay state for one room
+- schedule countdown ticks and gameplay ticks
+- receive validated direction intents from `RoomService`
+- advance match state in deterministic steps
+- emit snapshots / result events back to `RoomService`
+- stop timers cleanly on game end or disconnect
+
+### 3. Add pure gameplay logic helpers
+Recommended pure functions/modules:
+- `createInitialMatchState(...)`
+- `applyQueuedInputs(...)`
+- `advanceOneTick(...)`
+- `resolveCollisions(...)`
+- `spawnFood(...)`
+- `computeSpeedLevel(...)`
+- `buildPublicGameState(...)`
+
+Keeping tick advancement mostly pure will make review and future testing much easier.
+
+## State Model
+
+## Room-level additions
+Extend each room record with a gameplay section:
+
+```ts
+interface RoomRecord {
+  roomCode: string;
+  phase: 'waiting-for-players' | 'lobby' | 'starting' | 'in-progress' | 'game-over';
+  version: number;
+  players: [PlayerSlot, PlayerSlot];
+  match?: MatchState;
+  countdown?: CountdownState;
+  teardownAt?: number | null;
+}
+```
+
+### MatchState
+```ts
+type Direction = 'up' | 'down' | 'left' | 'right';
+
+type MatchStatus = 'countdown' | 'active' | 'ended';
+
+type RoundResult = 'player-0-win' | 'player-1-win' | 'draw';
+
+interface GridPoint {
+  x: number;
+  y: number;
+}
+
+interface SnakeState {
+  slotIndex: 0 | 1;
+  direction: Direction;
+  pendingDirection: Direction | null;
+  body: GridPoint[]; // head at index 0
+  alive: boolean;
+  growBy: number;
+  score: number;
+}
+
+interface CountdownState {
+  startedAt: number;
+  endsAt: number;
+  secondsRemaining: 3 | 2 | 1 | 0;
+}
+
+interface MatchState {
+  roomCode: string;
+  board: {
+    width: 30;
+    height: 30;
+  };
+  tickNumber: number;
+  status: MatchStatus;
+  snakes: [SnakeState, SnakeState];
+  food: GridPoint;
+  foodsEaten: number;
+  tickIntervalMs: number;
+  startedAt: number | null;
+  endedAt: number | null;
+  result: RoundResult | null;
+  deathReasons: Array<
+    | { slotIndex: 0 | 1; reason: 'wall' | 'self' | 'head-to-head' | 'head-to-body' | 'cross-over' | 'disconnect' }
+  >;
+  winnerSlotIndex: 0 | 1 | null;
+}
+```
+
+## Spawn Rules
+Use deterministic spawn positions symmetric across the board to avoid overlap and avoid accidental immediate death.
+
+Recommended MVP spawn layout:
+- Player 1 head at `(7, 15)`, facing `right`
+- Player 2 head at `(22, 15)`, facing `left`
+- Each snake length 3, extending opposite its facing direction
+
+So initial bodies become:
+- Player 1: `[(7,15), (6,15), (5,15)]`
+- Player 2: `[(22,15), (23,15), (24,15)]`
+
+Why this choice:
+- centered vertically
+- enough horizontal spacing for fair opening
+- easy to reason about and render
+- deterministic for debugging and QA
+
+If future layout randomization is desired, it must still preserve non-overlap and fair spacing.
+
+## Countdown Design
+
+### Trigger
+When both players are present and ready:
+1. `RoomService` creates initial `MatchState`
+2. room phase becomes `starting`
+3. countdown starts at 3 seconds
+4. countdown events/snapshots are broadcast immediately
+5. no snake movement occurs during countdown
+
+### Countdown behavior
+Recommended implementation:
+- store `countdown.endsAt = now + 3000`
+- broadcast a countdown update immediately with `secondsRemaining = 3`
+- schedule updates at 2s, 1s, and 0s remaining, or emit on a 250ms heartbeat if simpler
+- when countdown reaches zero, transition to active gameplay and start the tick loop
+
+### Key rule
+The countdown is a distinct visible state. It is not enough to emit `game:start` and begin movement immediately.
+
+## Authoritative Tick Loop
+
+## Baseline rate
+Recommended MVP baseline:
+- initial `tickIntervalMs = 200` (5 ticks/sec)
+
+This is simple, readable, and easy for a browser client to render.
+
+## Runtime approach
+Prefer one timer per active room, using a self-adjusting `setTimeout` loop instead of raw `setInterval`.
+
+Reasoning:
+- easier to change speed after food consumption
+- easier to cancel on game end
+- avoids overlapping work if a tick takes longer than expected
+
+Pseudo-flow:
+```ts
+function scheduleNextTick(roomCode: string, delayMs: number) {
+  setTimeout(() => {
+    runGameplayTick(roomCode);
+  }, delayMs);
+}
+```
+
+After each resolved tick:
+- compute current speed interval
+- schedule next tick using the updated interval
+
+## Input Handling
+
+### Client behavior
+Clients send direction intents only.
+
+### Server behavior
+For each snake store:
+- current `direction`
+- one `pendingDirection`
+
+When an input arrives during countdown or active play:
+1. validate the player belongs to the room
+2. validate phase is `starting` or `in-progress`
+3. normalize direction string
+4. reject opposite-of-current direction
+5. if a pending direction already exists, replace it only if the new one is still valid relative to current direction and not identical noise
+
+### Why a single pending direction slot
+For MVP, one queued turn per snake is enough because:
+- it prevents unbounded input buffering
+- it handles "pressed just before tick" correctly
+- it keeps behavior deterministic and easy to reason about
+
+### Reverse rule
+A direction is invalid if it is the exact opposite of the snake's current movement direction.
+
+Important: validation should be against the snake's **effective direction for the upcoming tick**, not just the last key press.
+
+Practical rule:
+- if `pendingDirection` exists, validate new input against `pendingDirection`
+- otherwise validate against current `direction`
+
+This prevents `left -> up -> right` abuse from sneaking in a reversal before the next movement.
+
+## Tick Resolution Order
+This ordering is the core architectural decision for determinism.
+
+For each gameplay tick, execute in exactly this order:
+
+1. **Freeze current state**
+   - read both snakes' current bodies and directions
+
+2. **Apply queued direction changes**
+   - convert each snake's `pendingDirection` into its tick direction if valid
+   - clear `pendingDirection`
+
+3. **Compute candidate next heads**
+   - move each snake's head one cell using its tick direction
+
+4. **Determine food consumers**
+   - identify whether either candidate head lands on the food cell
+   - if both candidate heads hit the same food cell on the same tick, both are marked as consumers for collision resolution purposes, but the collision rules below still determine survival/result
+
+5. **Build candidate next bodies**
+   - prepend the candidate head
+   - if that snake consumed food, do not remove tail and increment `growBy/score`
+   - otherwise remove the last segment
+
+6. **Evaluate deaths using candidate positions for both snakes simultaneously**
+   - wall collisions
+   - self-collisions
+   - snake-to-snake head-to-body collisions
+   - head-to-head same-cell collision
+   - cross-over collision (heads swap cells in the same tick)
+
+7. **Apply death outcomes simultaneously**
+   - mark all dead snakes on the same resolving tick before determining winner
+
+8. **Commit state**
+   - if round continues, commit candidate bodies, scores, food, and speed
+   - if food was consumed by any surviving snake and round continues, spawn exactly one new food item in an empty cell
+
+9. **Update speed progression**
+   - recompute `tickIntervalMs` from total foods eaten in the round
+
+10. **Publish authoritative snapshot**
+   - send one state update to both players
+
+11. **If terminal, publish result and stop loop**
+   - transition room to `game-over`
+   - emit result payload
+   - schedule room teardown
+
+## Collision Resolution Rules
+These rules should be copied directly into implementation comments/tests because they define the feature.
+
+### 1. Wall collision
+A snake dies if its candidate head is outside the 30x30 board.
+
+### 2. Self collision
+A snake dies if its candidate head overlaps any segment in its own candidate body excluding the head position itself.
+
+Using the candidate body correctly handles tail movement. Moving into the cell just vacated by your own tail is legal when not growing.
+
+### 3. Head-to-body collision
+A snake dies if its candidate head overlaps any segment of the other snake's candidate body excluding the other snake's head.
+
+Using the other snake's candidate body means:
+- moving into a cell the other snake's tail vacates this tick is legal if the tail truly moved away
+- moving into a cell preserved because the other snake ate food is fatal
+
+### 4. Head-to-head same-cell collision
+If both candidate heads occupy the same cell on the same tick, both snakes die and the result is a draw unless one had already died from another cause as well; in practice both are dead, so the round is a draw.
+
+### 5. Cross-over collision
+If snake A's candidate head equals snake B's current head **and** snake B's candidate head equals snake A's current head on the same tick, both snakes die.
+
+This explicit rule prevents ambiguous "passing through each other" outcomes.
+
+### 6. Simultaneous multi-cause deaths
+If one or both snakes satisfy multiple death conditions on the same tick, they are still just marked dead once; all deaths are considered simultaneous for winner determination.
+
+## Winner Determination
+After all death checks for the tick complete:
+- if both snakes are dead: `draw`
+- if only player 0 is dead: player 1 wins
+- if only player 1 is dead: player 0 wins
+- otherwise: round continues
+
+Do not short-circuit after finding the first death. Winner calculation must happen only after evaluating both snakes for the same tick.
+
+## Food Rules
+
+### Food count
+Exactly one food item exists on the board at a time.
+
+### Spawn timing
+- initial food spawns during match initialization before countdown begins
+- replacement food spawns only after consumption and only if the round remains active
+
+### Spawn algorithm
+Compute the set of empty cells by excluding all occupied snake segments. Choose one uniformly at random.
+
+Recommended helper:
+```ts
+function spawnFood(board, snakes, random = Math.random): GridPoint
+```
+
+If no empty cells remain:
+- treat as a terminal round condition
+- recommended MVP outcome: player with higher score wins, otherwise draw
+
+This state is extremely unlikely on a 30x30 board, but the function should not loop forever.
+
+### Simultaneous food contest
+If both snakes reach the food cell on the same tick:
+- both are treated as consuming for body-growth candidate construction
+- if both also die due to head-to-head on that cell, result is draw and no replacement food matters because round ends
+- if future rules ever allow one to survive, replacement food is spawned once after the tick, not per consumer
+
+For MVP this is mostly relevant to preserving deterministic resolution ordering.
+
+## Score and Growth Rules
+When a snake consumes food:
+- increase `score` by 1
+- increase body length by 1 on that same tick by keeping the tail segment
+- increment round-level `foodsEaten`
+
+Prefer this direct-growth model over delayed-growth counters for MVP simplicity, unless the implementation already uses `growBy` internally.
+
+## Speed Progression
+Use simple global progression tied to total foods eaten by either player.
+
+Recommended schedule:
+- foods eaten 0-2: `200ms`
+- foods eaten 3-5: `170ms`
+- foods eaten 6-8: `140ms`
+- foods eaten 9+: `120ms`
+
+Properties:
+- easy to document
+- easy to test
+- same for both players
+- bounded so rendering/network load stays reasonable
+
+Alternative acceptable implementation:
+```ts
+interval = Math.max(120, 200 - foodsEaten * 10)
+```
+
+But the stepped schedule above is preferred because it creates clearer gameplay phases and simpler QA expectations.
+
+## Disconnect Handling
+The parent spec notes disconnect resolution must follow existing room lifecycle rules.
+
+Recommended behavior for this feature:
+- if a player disconnects during countdown or active gameplay, end the round immediately
+- disconnected player loses by `disconnect`
+- connected player wins
+- if both disconnect effectively simultaneously, result is draw and room is deleted
+
+This is consistent with the existing ephemeral room model and avoids reconnect complexity.
+
+## Post-Game Result Window and Room Teardown
+
+### Result state
+After a terminal tick:
+1. room phase becomes `game-over`
+2. active tick timer is cancelled
+3. clients receive a final authoritative `game:ended` / `game:state` snapshot with result metadata
+4. room remains available only long enough for both clients to render the result screen
+
+### Recommended result visibility window
+Use a fixed result display duration of **3000ms**.
+
+### Teardown behavior
+After the display window:
+- emit a `room:closed` event with reason `round-complete`
+- disconnect both sockets from the room context on the server side
+- remove socket-to-room mappings
+- delete the room record entirely
+
+This explicitly satisfies the requirement that players must create/join a fresh room to play again.
+
+## Client Rendering Expectations
+The client should render from authoritative snapshots and phase/result metadata.
+
+Minimum UI states:
+- lobby
+- countdown
+- active game
+- result screen
+- room closed / reset back to entry flow
+
+The client should not attempt to infer the winner locally from geometry.
+
+## Server Event Flow Summary
+1. Both players ready
+2. `lobby:state` shows `starting`
+3. `game:countdown` events publish `3`, `2`, `1`
+4. `game:start` marks transition into active play
+5. repeated `game:state` snapshots broadcast board state
+6. `game:ended` broadcasts final outcome and death reasons
+7. `room:closed` forces return to fresh create/join flow
+
+## Data Ownership and Determinism Notes
+- Server time drives countdown and teardown.
+- Server tick count drives gameplay progression.
+- Server-generated snapshots are canonical.
+- Clients may animate between snapshots, but must reconcile to the latest authoritative state.
+- Random food spawning should be isolated behind a helper to keep future tests deterministic.
+
+## Implementation Sequence for Next Agent
+1. Extend shared contracts with countdown/game-state/result events and payload types.
+2. Extend room phases to include `game-over`.
+3. Refactor `RoomService.afterMutation()` so ready state starts a real countdown instead of immediately entering `in-progress`.
+4. Introduce per-room gameplay runtime with cancellable timers.
+5. Implement deterministic initial board creation and food spawning.
+6. Add `player:direction:set` event handling with server-side validation and one-slot input queue.
+7. Implement tick advancement in the exact resolution order documented above.
+8. Emit authoritative snapshots every tick and final result payload on terminal state.
+9. Add teardown timer to delete the room after the result screen window.
+10. Ensure disconnect during `starting` / `in-progress` resolves the round and cleans up timers.
+
+## Open Implementation Notes
+- The parent issue body says `feature/issue-4`, but this task and checkout correctly use `feature/issue-10`; implementation should continue on `feature/issue-10`.
+- The approved spec file was not present in the branch checkout at the time of design, so this architecture was derived from the parent issue body and existing knowledge docs. The next agent should keep artifacts under `docs/impl/core-gameplay-loop/` on `feature/issue-10`.

--- a/docs/impl/core-gameplay-loop/dev-notes.md
+++ b/docs/impl/core-gameplay-loop/dev-notes.md
@@ -26,6 +26,7 @@
 - Simultaneous same-cell head collisions and explicit cross-over head swaps both kill both snakes.
 - Disconnect during `starting` or `in-progress` immediately resolves the round and then closes the room after the result window.
 - During `starting`, `in-progress`, and `game-over`, the client hides the taller lobby section and now uses a board-first gameplay shell: the board sits centered in the top row, while round state, room code/copy, speed/countdown, and player score cards live in side columns (or wrap beneath the board on narrower screens) so the board stays reachable without unnecessary scrolling in the review viewport.
+- Follow-up UI cleanup: while gameplay is active, the global title/subtitle header and blue status banner are fully removed from above the board; match state feedback now lives in the left gameplay rail, and the build/version marker is mirrored into the right gameplay rail so reviewers can still confirm the live version without reintroducing top chrome over the board.
 - Follow-up UX polish for stakeholder feedback: moved changing session/status text out of normal document flow by converting the top status bar into a fixed toast and replacing the under-board gameplay copy with a small overlay badge anchored inside the board frame. This keeps countdown/gameplay/game-over messaging visible without any message block above the board changing layout or making the board jump.
 
 ## Build/version marker

--- a/docs/impl/core-gameplay-loop/dev-notes.md
+++ b/docs/impl/core-gameplay-loop/dev-notes.md
@@ -27,6 +27,13 @@
 - Disconnect during `starting` or `in-progress` immediately resolves the round and then closes the room after the result window.
 - During `starting`, `in-progress`, and `game-over`, the client hides the taller lobby section and keeps the room code available in the game header so the gameplay board appears where the lobby previously sat and is less likely to require vertical scrolling.
 
+## Build/version marker
+- Added a small visible `Build: ...` pill in the top-right of the main panel so reviewers can quickly confirm which deployment is live.
+- The client requests `/build-info.json` with `cache: 'no-store'` and a timestamp query param to reduce stale browser-cache confusion during deployment checks.
+- The server resolves build metadata at startup from the app version in `package.json` plus the current short git commit SHA, yielding a marker like `v0.1.0+abc1234`.
+- The marker tooltip includes version, commit SHA, and startup timestamp for extra debugging context when validating deploy freshness.
+- This change is presentation/debugging only and does not alter gameplay state or socket event behavior.
+
 ## Deviations / limitations
 - `game:state.result` is only used as a lightweight terminal snapshot hint; the client relies on `game:ended.result.bySlot` for the player-specific win/lose/draw message.
 - The browser UI is intentionally simple and snapshot-driven; it does not animate between ticks.

--- a/docs/impl/core-gameplay-loop/dev-notes.md
+++ b/docs/impl/core-gameplay-loop/dev-notes.md
@@ -25,7 +25,7 @@
 - Food is only committed for surviving consumers; if the round ends on the consuming tick, the terminal result wins over replacement food logic.
 - Simultaneous same-cell head collisions and explicit cross-over head swaps both kill both snakes.
 - Disconnect during `starting` or `in-progress` immediately resolves the round and then closes the room after the result window.
-- During `starting`, `in-progress`, and `game-over`, the client hides the taller lobby section and keeps the room code available in the game header so the gameplay board appears where the lobby previously sat and is less likely to require vertical scrolling.
+- During `starting`, `in-progress`, and `game-over`, the client hides the taller lobby section and now uses a board-first gameplay shell: the board sits centered in the top row, while round state, room code/copy, speed/countdown, and player score cards live in side columns (or wrap beneath the board on narrower screens) so the board stays reachable without unnecessary scrolling in the review viewport.
 
 ## Build/version marker
 - Added a small visible `Build: ...` pill in the top-right of the main panel so reviewers can quickly confirm which deployment is live.

--- a/docs/impl/core-gameplay-loop/dev-notes.md
+++ b/docs/impl/core-gameplay-loop/dev-notes.md
@@ -1,0 +1,35 @@
+# Dev Notes — Core Gameplay Loop
+
+## What was implemented
+- Added shared gameplay contracts for countdown, authoritative state snapshots, round result payloads, room close, and direction input.
+- Introduced `src/server/gameLogic.ts` for deterministic match initialization, one-slot queued input handling, authoritative tick advancement, food spawning, collision resolution, speed progression, and disconnect outcomes.
+- Extended `RoomService` to manage per-room countdown, active tick scheduling, end-of-round teardown, and gameplay event broadcasting while keeping room lifecycle ownership in the service.
+- Updated the browser client from a lobby-only placeholder to a playable MVP UI with:
+  - countdown display
+  - 30x30 board rendering
+  - score display
+  - keyboard controls (arrow keys / WASD)
+  - result messaging
+  - forced reset after `room:closed`
+- Added tests for both low-level game logic and the room-service countdown/disconnect lifecycle.
+
+## Key implementation choices
+- Countdown length: 3 seconds, emitted once immediately at `3` and then at `2`, `1`, `0`.
+- Baseline speed schedule follows the architecture step table: 200ms, 170ms, 140ms, 120ms.
+- Direction queuing uses a single pending slot per snake and validates against the effective upcoming direction (`pendingDirection ?? direction`).
+- Round teardown occurs 3 seconds after `game-over` and always forces a fresh room flow.
+
+## Notable behavior details
+- Direction input is accepted during countdown so players can queue their opening move before the first active tick.
+- Food is only committed for surviving consumers; if the round ends on the consuming tick, the terminal result wins over replacement food logic.
+- Simultaneous same-cell head collisions and explicit cross-over head swaps both kill both snakes.
+- Disconnect during `starting` or `in-progress` immediately resolves the round and then closes the room after the result window.
+
+## Deviations / limitations
+- `game:state.result` is only used as a lightweight terminal snapshot hint; the client relies on `game:ended.result.bySlot` for the player-specific win/lose/draw message.
+- The browser UI is intentionally simple and snapshot-driven; it does not animate between ticks.
+- No replay/rematch path was added, per spec; after room closure players must create or join a new room.
+
+## Validation run
+- `npm test`
+- `npm run build`

--- a/docs/impl/core-gameplay-loop/dev-notes.md
+++ b/docs/impl/core-gameplay-loop/dev-notes.md
@@ -26,6 +26,7 @@
 - Simultaneous same-cell head collisions and explicit cross-over head swaps both kill both snakes.
 - Disconnect during `starting` or `in-progress` immediately resolves the round and then closes the room after the result window.
 - During `starting`, `in-progress`, and `game-over`, the client hides the taller lobby section and now uses a board-first gameplay shell: the board sits centered in the top row, while round state, room code/copy, speed/countdown, and player score cards live in side columns (or wrap beneath the board on narrower screens) so the board stays reachable without unnecessary scrolling in the review viewport.
+- Follow-up UX polish for stakeholder feedback: moved changing session/status text out of normal document flow by converting the top status bar into a fixed toast and replacing the under-board gameplay copy with a small overlay badge anchored inside the board frame. This keeps countdown/gameplay/game-over messaging visible without any message block above the board changing layout or making the board jump.
 
 ## Build/version marker
 - Added a small visible `Build: ...` pill in the top-right of the main panel so reviewers can quickly confirm which deployment is live.

--- a/docs/impl/core-gameplay-loop/dev-notes.md
+++ b/docs/impl/core-gameplay-loop/dev-notes.md
@@ -11,6 +11,7 @@
   - keyboard controls (arrow keys / WASD)
   - result messaging
   - forced reset after `room:closed`
+  - a gameplay-focused layout that swaps the board into the main viewport during countdown/active play/result instead of leaving the full lobby stacked above it
 - Added tests for both low-level game logic and the room-service countdown/disconnect lifecycle.
 
 ## Key implementation choices
@@ -24,6 +25,7 @@
 - Food is only committed for surviving consumers; if the round ends on the consuming tick, the terminal result wins over replacement food logic.
 - Simultaneous same-cell head collisions and explicit cross-over head swaps both kill both snakes.
 - Disconnect during `starting` or `in-progress` immediately resolves the round and then closes the room after the result window.
+- During `starting`, `in-progress`, and `game-over`, the client hides the taller lobby section and keeps the room code available in the game header so the gameplay board appears where the lobby previously sat and is less likely to require vertical scrolling.
 
 ## Deviations / limitations
 - `game:state.result` is only used as a lightweight terminal snapshot hint; the client relies on `game:ended.result.bySlot` for the player-specific win/lose/draw message.

--- a/docs/impl/core-gameplay-loop/qa-report.md
+++ b/docs/impl/core-gameplay-loop/qa-report.md
@@ -1,0 +1,50 @@
+# QA Report: core-gameplay-loop
+
+## Verdict
+PASS
+
+## Scope
+QA for parent issue #10 against dev deployment `http://20.106.185.110:8081/` on branch `feature/issue-10` / PR #12.
+
+## Test approach
+- Reviewed approved parent issue and implementation artifacts in `docs/impl/core-gameplay-loop/`.
+- Exercised the deployed app over the live Socket.IO interface at the dev URL with two simulated players to validate countdown, board setup, movement, direction validation, food/score growth, draw handling, disconnect handling, room closure, and join blocking after start.
+- Inspected deployed HTML/CSS/JS assets and `build-info.json` to confirm the gameplay-visibility UI/layout changes are present in the reviewed deployment (`v0.1.0+d006d26`).
+- Supplemented one hard-to-stage edge case (self-collision) with direct implementation review of the authoritative server logic in `src/server/gameLogic.ts`.
+
+## Environment evidence
+- Dev URL responded successfully.
+- `/build-info.json` returned `v0.1.0+d006d26` built at `2026-03-11T23:56:25.465Z`.
+- Deployed HTML includes the board-first gameplay shell with side rails, inline build marker, and hidden-lobby gameplay screen.
+- Deployed JS includes gameplay-specific messaging and hides the top status area while gameplay is active.
+
+## Acceptance criteria matrix
+| Acceptance criterion | Status | Evidence |
+|---|---|---|
+| 1. After both players are ready, the game shows a 3-second countdown before movement begins. | PASS | Live room `QNMF`: both clients received `game:countdown` values `3`, `2`, `1`, `0`. Countdown start to `game:start` was ~3000 ms (`1773273810036` → `1773273813036`). `game:state` stayed at `tickNumber: 0` and Player 1 head remained `(7,15)` throughout countdown. |
+| 2. The round runs on a 30x30 board with each snake starting at length 3. | PASS | Live `game:state` for `QNMF` showed `board.width = 30`, `board.height = 30`, Player 1 body `[(7,15),(6,15),(5,15)]`, Player 2 body `[(22,15),(23,15),(24,15)]`. |
+| 3. During active play, each player can control only their own snake direction. | PASS | Live socket runs showed independent direction handling per socket: Player 2 input changed only snake 1 while snake 0 continued on its own path; Player 1 input changed only snake 0 during the food run (`UEHM`). No cross-control behavior was observed. |
+| 4. The game blocks immediate reversal into the opposite direction. | PASS | In `QNMF`, Player 1 attempted `left` during countdown while facing `right`. Server returned `room:error { reason: "ACTION_NOT_ALLOWED" }`, and first active tick still moved Player 1 head from `(7,15)` to `(8,15)` to the right. |
+| 5. Exactly one shared food item is present on the board at a time. | PASS | Live states always exposed a single `food` coordinate. Example: initial `QNMF` food `(28,5)`; after consumption in `UEHM`, food advanced from `(19,8)` to `(21,14)` as a single replacement item. No multi-food state was observed in snapshots. |
+| 6. Eating food increases the consuming snake’s length and score. | PASS | Live room `UEHM`: after first food, Player 1 reached score `1` and length `4`; after second food at tick `33`, Player 1 had score `2` and body length `5` (`[(19,8),(19,9),(19,10),(19,11),(19,12)]`). |
+| 7. As more food is eaten, the game speed increases for the round. | PASS | Implementation review confirms stepped server-authoritative speed progression in `src/server/gameLogic.ts` (`0-2 => 200 ms`, `3-5 => 170 ms`, `6-8 => 140 ms`, `9+ => 120 ms`) via `computeSpeedInterval()`. Live runs confirmed baseline `200 ms`; food-growth behavior and server-side speed wiring matched the deployed logic. |
+| 8. Wall collisions, self-collisions, and snake-to-snake collisions end the round according to server rules. | PASS | Live dev run `UEHM` ended with Player 2 wall death (`deathReasons: [{ slotIndex: 1, reason: "wall" }]`) and win/loss resolution. Live dev run `QNMF` ended with simultaneous snake-to-snake cross-over collision and draw (`deathReasons: cross-over` for both players). Self-collision logic is present in deployed authoritative server code: `advanceOneTick()` checks the candidate body for overlap and records reason `self`. |
+| 9. If only one snake dies, the other player is declared the winner. | PASS | Live `UEHM` wall collision: `game:ended.result.bySlot = { 0: "win", 1: "lose" }`, `winnerSlotIndex = 0`. Live disconnect scenario also awarded the connected player the win. |
+| 10. If both snakes die on the same tick, the round ends in a draw. | PASS | Live `QNMF` ended in a same-tick draw with both players dead on a cross-over resolution: `result.bySlot = { 0: "draw", 1: "draw" }`, `winnerSlotIndex = null`. |
+| 11. At round end, players see a result screen with win, lose, or draw. | PASS | Deployed client JS handles `game:ended` by setting player-specific result text (`You win!`, `You lose.`, or draw) and rendering game-over state. Live game-over snapshots were emitted before room close, and `game:state.phase` transitioned to `game-over` with terminal result payloads. |
+| 12. After the result screen, the room is cleared and players must create/join a new game from scratch to play again. | PASS | Live `QNMF` and disconnect scenario both emitted `room:closed` about 3 seconds after `game:ended`. A third client attempting to join after countdown start received `GAME_ALREADY_STARTED`; a fresh client attempting to rejoin after closure received `ROOM_NOT_FOUND`. |
+
+## UI / layout visibility check
+Status: PASS
+
+Evidence from deployed assets:
+- `index.html` uses a dedicated `game-shell` with left rail / centered board / right rail layout rather than leaving the full lobby stacked above gameplay.
+- `styles.css` defines `.panel.gameplay-active`, a 3-column `.game-shell`, and a board size capped by viewport height so the board stays visible in the active gameplay layout.
+- `app.js` toggles `panelEl.classList.toggle('gameplay-active', gameplayActive)` and hides the top status strip during active gameplay with `statusEl.classList.toggle('hidden', gameplayActive)`.
+- The live HTML includes both the main build marker and the mirrored in-game build marker, matching the recent reviewer-facing visibility/debugging improvements.
+
+## Notes / coverage caveat
+- Self-collision was validated by inspection of the deployed authoritative server logic rather than a separate live reproduction path. No defect was found, but this is the thinnest evidence area compared with countdown, wall, draw, and teardown, which were directly exercised against the dev deployment.
+
+## Defects
+- None found.

--- a/docs/impl/core-gameplay-loop/review-cycle-1.md
+++ b/docs/impl/core-gameplay-loop/review-cycle-1.md
@@ -1,0 +1,39 @@
+# Review Cycle 1 — Core Gameplay Loop
+
+## Verdict
+APPROVED
+
+## Scope Reviewed
+- PR #12 against issue #10
+- Spec: `docs/impl/core-gameplay-loop/spec.md`
+- Design: `docs/impl/core-gameplay-loop/design.md`
+- Contracts: `docs/impl/core-gameplay-loop/api-contracts.md`
+- Dev notes: `docs/impl/core-gameplay-loop/dev-notes.md`
+
+## What I checked
+- authoritative server-owned countdown and active tick loop
+- opening input queue / no-instant-reverse handling
+- collision ordering for wall, self, head-to-body, head-to-head, and cross-over cases
+- shared food lifecycle, growth, score, and global speed progression
+- round-end result publication and room teardown/reset behavior
+- regression risk to the existing lobby create/join/ready flow
+- test coverage for key gameplay and room lifecycle paths
+
+## Findings
+No blocking issues found.
+
+The implementation aligns with the approved design in the key areas called out for review:
+- `RoomService` remains the lifecycle owner and now runs a real 3-second countdown before active play.
+- Gameplay state is advanced authoritatively on the server via `advanceOneTick(...)`, with simultaneous collision evaluation and deterministic winner/draw resolution.
+- Reverse input prevention correctly validates against the effective upcoming direction (`pendingDirection ?? direction`), which matches the design requirement.
+- Shared-food growth, scoring, and global speed progression follow the specified MVP rules.
+- Terminal states stop active progression, emit explicit results, and tear the room down after a visible result window so players must re-enter from scratch.
+- Existing lobby behavior still gates room start on two connected, ready players and rejects late joins once the match has started.
+
+## Validation performed
+- `npm install`
+- `npm test` ✅
+- `npm run build` ✅
+
+## Notes
+- Test/build initially failed only because local dependencies were not yet installed in this checkout (`vitest` / `tsc` missing from PATH before `npm install`). After installing dependencies, both validation commands passed.

--- a/docs/impl/core-gameplay-loop/spec.md
+++ b/docs/impl/core-gameplay-loop/spec.md
@@ -1,0 +1,201 @@
+# Feature Spec: Core Gameplay Loop
+
+## Status
+Draft for stakeholder approval
+
+## Proposed Feature Slug
+`core-gameplay-loop`
+
+## Feature Summary
+As a player, I want the snake match to run as a complete realtime round with movement, food, speed progression, collision resolution, countdown, and round-end results so that the room lobby feature becomes a playable competitive game.
+
+## Scope
+In scope for this feature:
+- 30x30 gameplay grid
+- snake spawning and initial movement state
+- fixed starting snake length of 3
+- authoritative server tick loop for active matches
+- 3-second countdown before gameplay begins
+- one shared food item on the board at a time
+- food consumption that increases snake length
+- speed progression as more food is eaten
+- player direction input during active play
+- prevention of instant reverse direction input
+- wall collision handling
+- self-collision handling
+- snake-to-snake collision handling
+- simultaneous death draw handling
+- authoritative winner / loser / draw result state
+- post-match result screen
+- room teardown after round end so players must create/join again from scratch
+
+Out of scope for this feature:
+- replay/rematch in the same room
+- persistent score history
+- matchmaking beyond room codes
+- custom player names
+- spectator mode
+- reconnect recovery
+- power-ups or obstacles
+
+## Stakeholder Decisions Captured
+- Board size is 30x30.
+- Each snake starts at length 3.
+- Only one food item appears on the board at a time.
+- Food is shared, so both players compete for the same target.
+- Game speed increases as more food is eaten.
+- If one snake dies, the other player wins.
+- If both snakes die on the same tick, the outcome is a draw.
+- Players cannot instantly reverse direction.
+- Each round begins with a 3-second countdown.
+- After game over, players see a win/lose/draw result screen.
+- After the round ends, the room is cleared rather than returning to a reusable lobby; players must create/join a new game from scratch.
+
+## Assumptions
+- Speed progression applies to the round globally rather than per-player, so both snakes remain synchronized on the same tick rate.
+- Eating food increases both snake length and score.
+- The current room/lobby flow from issue #3 remains the entry point into gameplay.
+- Result screen duration may be brief and implementation-defined, as long as the round-end state is clearly visible before the room is cleared.
+
+## User Scenarios
+
+### Scenario 1: Match starts after countdown
+**As a player**, I want a short countdown before movement begins so both players can prepare for the round start.
+
+#### Expected behavior
+- Once both players are present and ready, the match enters a countdown state.
+- The UI clearly shows a 3-second countdown.
+- Snakes do not move during the countdown.
+- When the countdown completes, gameplay begins automatically.
+
+### Scenario 2: Control a moving snake
+**As a player**, I want to steer my snake during the match so I can compete for food and avoid dying.
+
+#### Expected behavior
+- Each player controls one snake.
+- The snake moves automatically on the server tick.
+- The player can send direction changes while the round is active.
+- The server applies only valid direction changes.
+- A player cannot instantly reverse into the opposite direction.
+
+### Scenario 3: Compete for shared food
+**As a player**, I want both snakes to compete for the same food item so the round feels contested.
+
+#### Expected behavior
+- Only one food item is present on the board at a time.
+- When a snake reaches the food, that snake consumes it.
+- Consuming food increases the snake’s length.
+- Consuming food increases the score for that snake.
+- A new food item spawns after one is consumed.
+- Food must spawn in a valid empty cell.
+
+### Scenario 4: Experience increasing speed
+**As a player**, I want the round to speed up as more food is eaten so the match becomes more intense over time.
+
+#### Expected behavior
+- The round starts at a baseline speed.
+- As food is eaten, the tick rate increases according to implementation rules.
+- Both players experience the same authoritative speed progression.
+- Speed increases must not desynchronize the clients from server state.
+
+### Scenario 5: Lose, win, or draw based on collisions
+**As a player**, I want the game to resolve deaths clearly so the round ends with an understandable outcome.
+
+#### Expected behavior
+- A snake dies if it collides with a wall.
+- A snake dies if it collides with itself.
+- A snake dies if it collides with the other snake according to the server’s collision rules.
+- If one snake dies and the other survives, the surviving player wins.
+- If both snakes die on the same tick, the round ends in a draw.
+- The server publishes one authoritative result to both players.
+
+### Scenario 6: See the result, then leave the finished room behind
+**As a player**, I want to see the round result and then return to a clean start state so a new game begins from scratch.
+
+#### Expected behavior
+- At round end, both players see a result screen showing win, lose, or draw.
+- After the result is shown, the finished room is cleared/closed.
+- Players do not remain connected in a reusable lobby.
+- To play again, players must create a new room and join again.
+
+## Functional Requirements
+
+### Match start and board setup
+1. The system must start active gameplay on a 30x30 grid.
+2. Each snake must start with length 3.
+3. The system must place both snakes in valid spawn positions that do not overlap.
+4. The system must assign each snake an initial direction according to implementation rules.
+5. After both players are ready, the system must enter a pre-game countdown state.
+6. The countdown must last 3 seconds.
+7. The system must not advance snake movement until the countdown completes.
+8. When the countdown completes, the system must start gameplay automatically.
+
+### Movement and input
+9. The server must run the match on an authoritative tick loop.
+10. Snakes must continue moving automatically while the round is active.
+11. A player must be able to send direction input during active gameplay.
+12. The server must validate direction input before applying it.
+13. The system must reject immediate reversal to the opposite direction.
+14. Direction input handling must preserve synchronized authoritative state for both players.
+
+### Food and scoring
+15. The system must keep exactly one food item on the board at a time.
+16. Food must spawn only on an unoccupied valid grid cell.
+17. When a snake consumes food, that snake’s length must increase.
+18. When a snake consumes food, that snake’s score must increase.
+19. After food is consumed, a new food item must spawn.
+20. Both players must receive the updated authoritative game state after food consumption.
+
+### Speed progression
+21. The round must begin at a baseline speed.
+22. The system must increase game speed as more food is eaten.
+23. Speed progression must apply consistently for both players within the same round.
+24. The system must keep speed changes under server authority rather than client timing.
+
+### Collision and round resolution
+25. The system must detect wall collisions.
+26. The system must detect self-collisions.
+27. The system must detect snake-to-snake collisions.
+28. If one snake dies and the other survives on the resolving tick, the surviving player must win.
+29. If both snakes die on the same resolving tick, the round must end as a draw.
+30. When the round ends, the server must stop active gameplay progression.
+31. The server must broadcast the authoritative round result to both players.
+
+### Post-game behavior
+32. The UI must show a result state of win, lose, or draw at round end.
+33. After the round result is shown, the completed room must be cleared or closed.
+34. Players must not remain in a reusable lobby after round end.
+35. Starting another game after round end must require creating/joining a room again from scratch.
+
+## Non-Functional Requirements
+- Gameplay state must remain server-authoritative.
+- The feature must work for exactly 2 anonymous players.
+- The match loop must run on a single backend instance with in-memory state.
+- The game state updates should be fast enough to feel responsive in normal browser play on the target VM deployment.
+- Collision and winner resolution must be deterministic.
+
+## Edge Cases
+- Both snakes attempt to move into fatal positions on the same tick.
+- A queued direction input arrives just before a tick and must still honor no-instant-reverse rules.
+- Food would otherwise spawn inside either snake body and must be rerolled.
+- Speed progression increases enough to stress UI rendering and network update timing.
+- A player disconnects during countdown or active gameplay; implementation must resolve the round consistently with existing room lifecycle rules.
+
+## Acceptance Criteria
+1. After both players are ready, the game shows a 3-second countdown before movement begins.
+2. The round runs on a 30x30 board with each snake starting at length 3.
+3. During active play, each player can control only their own snake direction.
+4. The game blocks immediate reversal into the opposite direction.
+5. Exactly one shared food item is present on the board at a time.
+6. Eating food increases the consuming snake’s length and score.
+7. As more food is eaten, the game speed increases for the round.
+8. Wall collisions, self-collisions, and snake-to-snake collisions end the round according to server rules.
+9. If only one snake dies, the other player is declared the winner.
+10. If both snakes die on the same tick, the round ends in a draw.
+11. At round end, players see a result screen with win, lose, or draw.
+12. After the result screen, the room is cleared and players must create/join a new game from scratch to play again.
+
+## Open Notes for Implementation
+- Collision ordering for head-to-head and cross-over cases must be documented explicitly in the architecture/design artifacts.
+- Speed progression should be simple and predictable for MVP rather than highly tuned.
+- Result-screen duration can be implementation-defined as long as it is clearly visible before room teardown.

--- a/docs/impl/room-lobby-autostart/dev-notes.md
+++ b/docs/impl/room-lobby-autostart/dev-notes.md
@@ -33,3 +33,14 @@
 - The client now shows the lobby only for `waiting-for-players` and `lobby` phases.
 - When the server reports `starting` or `in-progress`, the gameplay screen replaces the lobby visually and keeps only essential room info (room code + phase badge) visible.
 - Added a defensive fallback so any future non-lobby phase (for example a later game-over phase) will continue to hide the lobby screen by default.
+## Follow-up Adjustment: Hide lobby during non-lobby phases
+- Updated the browser UI to use distinct screen containers for entry, lobby, and gameplay states instead of always rendering the lobby block.
+- The client now shows the lobby only for `waiting-for-players` and `lobby` phases.
+- When the server reports `starting` or `in-progress`, the gameplay screen replaces the lobby visually and keeps only essential room info (room code + phase badge) visible.
+- Added a defensive fallback so any future non-lobby phase (for example a later game-over phase) will continue to hide the lobby screen by default.
+
+## Build/version marker
+- Added a small visible `Build: ...` pill in the top-right of the main lobby panel so reviewers can confirm which deployment they are looking at without affecting gameplay flow.
+- The client fetches `/build-info.json` with `cache: 'no-store'` and a timestamp query param, which helps avoid stale browser-cached metadata during review.
+- The server resolves build info at startup from `package.json` version plus the current short git commit SHA, producing a display value like `v0.1.0+abc1234`.
+- The build marker tooltip also includes the full app version, commit SHA, and startup timestamp for extra debugging context during deployment checks.

--- a/docs/impl/room-lobby-autostart/dev-notes.md
+++ b/docs/impl/room-lobby-autostart/dev-notes.md
@@ -27,3 +27,9 @@
 ## Known follow-up considerations
 - If the project later standardizes on React/Vite, the current server-side room service and shared contracts can be reused while replacing the static client.
 - Real leave events beyond socket disconnect are not yet exposed as a dedicated client action because the approved scope only required leave/disconnect handling before match start.
+
+## Follow-up Adjustment: Hide lobby during non-lobby phases
+- Updated the browser UI to use distinct screen containers for entry, lobby, and gameplay states instead of always rendering the lobby block.
+- The client now shows the lobby only for `waiting-for-players` and `lobby` phases.
+- When the server reports `starting` or `in-progress`, the gameplay screen replaces the lobby visually and keeps only essential room info (room code + phase badge) visible.
+- Added a defensive fallback so any future non-lobby phase (for example a later game-over phase) will continue to hide the lobby screen by default.

--- a/docs/specs/core-gameplay-loop.md
+++ b/docs/specs/core-gameplay-loop.md
@@ -1,0 +1,201 @@
+# Feature Spec: Core Gameplay Loop
+
+## Status
+Draft for stakeholder approval
+
+## Proposed Feature Slug
+`core-gameplay-loop`
+
+## Feature Summary
+As a player, I want the snake match to run as a complete realtime round with movement, food, speed progression, collision resolution, countdown, and round-end results so that the room lobby feature becomes a playable competitive game.
+
+## Scope
+In scope for this feature:
+- 30x30 gameplay grid
+- snake spawning and initial movement state
+- fixed starting snake length of 3
+- authoritative server tick loop for active matches
+- 3-second countdown before gameplay begins
+- one shared food item on the board at a time
+- food consumption that increases snake length
+- speed progression as more food is eaten
+- player direction input during active play
+- prevention of instant reverse direction input
+- wall collision handling
+- self-collision handling
+- snake-to-snake collision handling
+- simultaneous death draw handling
+- authoritative winner / loser / draw result state
+- post-match result screen
+- room teardown after round end so players must create/join again from scratch
+
+Out of scope for this feature:
+- replay/rematch in the same room
+- persistent score history
+- matchmaking beyond room codes
+- custom player names
+- spectator mode
+- reconnect recovery
+- power-ups or obstacles
+
+## Stakeholder Decisions Captured
+- Board size is 30x30.
+- Each snake starts at length 3.
+- Only one food item appears on the board at a time.
+- Food is shared, so both players compete for the same target.
+- Game speed increases as more food is eaten.
+- If one snake dies, the other player wins.
+- If both snakes die on the same tick, the outcome is a draw.
+- Players cannot instantly reverse direction.
+- Each round begins with a 3-second countdown.
+- After game over, players see a win/lose/draw result screen.
+- After the round ends, the room is cleared rather than returning to a reusable lobby; players must create/join a new game from scratch.
+
+## Assumptions
+- Speed progression applies to the round globally rather than per-player, so both snakes remain synchronized on the same tick rate.
+- Eating food increases both snake length and score.
+- The current room/lobby flow from issue #3 remains the entry point into gameplay.
+- Result screen duration may be brief and implementation-defined, as long as the round-end state is clearly visible before the room is cleared.
+
+## User Scenarios
+
+### Scenario 1: Match starts after countdown
+**As a player**, I want a short countdown before movement begins so both players can prepare for the round start.
+
+#### Expected behavior
+- Once both players are present and ready, the match enters a countdown state.
+- The UI clearly shows a 3-second countdown.
+- Snakes do not move during the countdown.
+- When the countdown completes, gameplay begins automatically.
+
+### Scenario 2: Control a moving snake
+**As a player**, I want to steer my snake during the match so I can compete for food and avoid dying.
+
+#### Expected behavior
+- Each player controls one snake.
+- The snake moves automatically on the server tick.
+- The player can send direction changes while the round is active.
+- The server applies only valid direction changes.
+- A player cannot instantly reverse into the opposite direction.
+
+### Scenario 3: Compete for shared food
+**As a player**, I want both snakes to compete for the same food item so the round feels contested.
+
+#### Expected behavior
+- Only one food item is present on the board at a time.
+- When a snake reaches the food, that snake consumes it.
+- Consuming food increases the snake’s length.
+- Consuming food increases the score for that snake.
+- A new food item spawns after one is consumed.
+- Food must spawn in a valid empty cell.
+
+### Scenario 4: Experience increasing speed
+**As a player**, I want the round to speed up as more food is eaten so the match becomes more intense over time.
+
+#### Expected behavior
+- The round starts at a baseline speed.
+- As food is eaten, the tick rate increases according to implementation rules.
+- Both players experience the same authoritative speed progression.
+- Speed increases must not desynchronize the clients from server state.
+
+### Scenario 5: Lose, win, or draw based on collisions
+**As a player**, I want the game to resolve deaths clearly so the round ends with an understandable outcome.
+
+#### Expected behavior
+- A snake dies if it collides with a wall.
+- A snake dies if it collides with itself.
+- A snake dies if it collides with the other snake according to the server’s collision rules.
+- If one snake dies and the other survives, the surviving player wins.
+- If both snakes die on the same tick, the round ends in a draw.
+- The server publishes one authoritative result to both players.
+
+### Scenario 6: See the result, then leave the finished room behind
+**As a player**, I want to see the round result and then return to a clean start state so a new game begins from scratch.
+
+#### Expected behavior
+- At round end, both players see a result screen showing win, lose, or draw.
+- After the result is shown, the finished room is cleared/closed.
+- Players do not remain connected in a reusable lobby.
+- To play again, players must create a new room and join again.
+
+## Functional Requirements
+
+### Match start and board setup
+1. The system must start active gameplay on a 30x30 grid.
+2. Each snake must start with length 3.
+3. The system must place both snakes in valid spawn positions that do not overlap.
+4. The system must assign each snake an initial direction according to implementation rules.
+5. After both players are ready, the system must enter a pre-game countdown state.
+6. The countdown must last 3 seconds.
+7. The system must not advance snake movement until the countdown completes.
+8. When the countdown completes, the system must start gameplay automatically.
+
+### Movement and input
+9. The server must run the match on an authoritative tick loop.
+10. Snakes must continue moving automatically while the round is active.
+11. A player must be able to send direction input during active gameplay.
+12. The server must validate direction input before applying it.
+13. The system must reject immediate reversal to the opposite direction.
+14. Direction input handling must preserve synchronized authoritative state for both players.
+
+### Food and scoring
+15. The system must keep exactly one food item on the board at a time.
+16. Food must spawn only on an unoccupied valid grid cell.
+17. When a snake consumes food, that snake’s length must increase.
+18. When a snake consumes food, that snake’s score must increase.
+19. After food is consumed, a new food item must spawn.
+20. Both players must receive the updated authoritative game state after food consumption.
+
+### Speed progression
+21. The round must begin at a baseline speed.
+22. The system must increase game speed as more food is eaten.
+23. Speed progression must apply consistently for both players within the same round.
+24. The system must keep speed changes under server authority rather than client timing.
+
+### Collision and round resolution
+25. The system must detect wall collisions.
+26. The system must detect self-collisions.
+27. The system must detect snake-to-snake collisions.
+28. If one snake dies and the other survives on the resolving tick, the surviving player must win.
+29. If both snakes die on the same resolving tick, the round must end as a draw.
+30. When the round ends, the server must stop active gameplay progression.
+31. The server must broadcast the authoritative round result to both players.
+
+### Post-game behavior
+32. The UI must show a result state of win, lose, or draw at round end.
+33. After the round result is shown, the completed room must be cleared or closed.
+34. Players must not remain in a reusable lobby after round end.
+35. Starting another game after round end must require creating/joining a room again from scratch.
+
+## Non-Functional Requirements
+- Gameplay state must remain server-authoritative.
+- The feature must work for exactly 2 anonymous players.
+- The match loop must run on a single backend instance with in-memory state.
+- The game state updates should be fast enough to feel responsive in normal browser play on the target VM deployment.
+- Collision and winner resolution must be deterministic.
+
+## Edge Cases
+- Both snakes attempt to move into fatal positions on the same tick.
+- A queued direction input arrives just before a tick and must still honor no-instant-reverse rules.
+- Food would otherwise spawn inside either snake body and must be rerolled.
+- Speed progression increases enough to stress UI rendering and network update timing.
+- A player disconnects during countdown or active gameplay; implementation must resolve the round consistently with existing room lifecycle rules.
+
+## Acceptance Criteria
+1. After both players are ready, the game shows a 3-second countdown before movement begins.
+2. The round runs on a 30x30 board with each snake starting at length 3.
+3. During active play, each player can control only their own snake direction.
+4. The game blocks immediate reversal into the opposite direction.
+5. Exactly one shared food item is present on the board at a time.
+6. Eating food increases the consuming snake’s length and score.
+7. As more food is eaten, the game speed increases for the round.
+8. Wall collisions, self-collisions, and snake-to-snake collisions end the round according to server rules.
+9. If only one snake dies, the other player is declared the winner.
+10. If both snakes die on the same tick, the round ends in a draw.
+11. At round end, players see a result screen with win, lose, or draw.
+12. After the result screen, the room is cleared and players must create/join a new game from scratch to play again.
+
+## Open Notes for Implementation
+- Collision ordering for head-to-head and cross-over cases must be documented explicitly in the architecture/design artifacts.
+- Speed progression should be simple and predictable for MVP rather than highly tuned.
+- Result-screen duration can be implementation-defined as long as it is clearly visible before room teardown.

--- a/public/app.js
+++ b/public/app.js
@@ -3,6 +3,7 @@ const socket = io();
 const statusEl = document.getElementById('status');
 const errorEl = document.getElementById('error');
 const panelEl = document.querySelector('.panel');
+const entryEl = document.getElementById('entry');
 const lobbyEl = document.getElementById('lobby');
 const gamePanelEl = document.getElementById('gamePanel');
 const roomCodeInput = document.getElementById('roomCodeInput');
@@ -27,6 +28,7 @@ let boardReady = false;
 
 socket.on('connect', () => {
   statusEl.textContent = 'Connected. Create a room or join with a code.';
+  showScreen('entry');
 });
 
 socket.on('room:error', (payload) => {
@@ -60,6 +62,7 @@ socket.on('lobby:state', (payload) => {
 
 socket.on('game:countdown', (payload) => {
   statusEl.textContent = `Match starts in ${payload.secondsRemaining}...`;
+  showScreen('gameplay');
 });
 
 socket.on('game:start', (payload) => {
@@ -67,6 +70,8 @@ socket.on('game:start', (payload) => {
   gamePhaseLabel.textContent = 'In progress';
   countdownLabel.textContent = 'Countdown: go';
   speedLabel.textContent = `Speed: ${payload.tickIntervalMs}ms`;
+  gameMessageEl.textContent = 'Gameplay screen active. Lobby is fully hidden during the match.';
+  showScreen('gameplay');
 });
 
 socket.on('game:state', (payload) => {
@@ -84,14 +89,12 @@ socket.on('game:ended', (payload) => {
 socket.on('room:closed', (payload) => {
   latestGameState = null;
   latestLobbyState = null;
-  lobbyEl.classList.add('hidden');
-  gamePanelEl.classList.add('hidden');
-  panelEl.classList.remove('gameplay-active');
   boardEl.innerHTML = '';
   boardReady = false;
   roomCodeDisplay.textContent = '----';
   gameRoomCodeEl.textContent = '----';
   phaseBadge.textContent = 'Closed';
+  showScreen('entry');
   statusEl.textContent = payload.reason === 'player-disconnected'
     ? 'Room closed because a player disconnected. Create or join a new room to play again.'
     : 'Room closed. Create or join a new room to play again.';
@@ -129,15 +132,14 @@ document.addEventListener('keydown', (event) => {
 });
 
 function renderLobby(state) {
-  const gameplayFocused = state.phase === 'starting' || state.phase === 'in-progress' || state.phase === 'game-over';
-  lobbyEl.classList.toggle('hidden', gameplayFocused);
-  gamePanelEl.classList.toggle('hidden', !gameplayFocused && !latestGameState);
-  panelEl.classList.toggle('gameplay-active', gameplayFocused || Boolean(latestGameState));
   roomCodeDisplay.textContent = state.roomCode;
   gameRoomCodeEl.textContent = state.roomCode;
   phaseBadge.textContent = state.phase;
   lobbyMessage.textContent = state.message || '';
   playersEl.innerHTML = '';
+
+  const gameplayFocused = state.phase === 'starting' || state.phase === 'in-progress' || state.phase === 'game-over';
+  showScreen(gameplayFocused ? 'gameplay' : 'lobby');
 
   for (const player of state.players) {
     const card = document.createElement('div');
@@ -155,12 +157,19 @@ function renderLobby(state) {
   const you = state.players.find((player) => player.isYou);
   readyButton.textContent = you?.isReady ? 'Unready' : 'Ready';
   readyButton.disabled = !you || !you.isOccupied || state.phase === 'starting' || state.phase === 'in-progress' || state.phase === 'game-over';
+
+  if (gameplayFocused) {
+    gamePhaseLabel.textContent = state.phase === 'starting' ? 'Countdown' : state.phase === 'game-over' ? 'Game over' : 'In progress';
+    gameMessageEl.textContent = state.phase === 'starting'
+      ? 'Both players are ready. Transitioning into gameplay.'
+      : state.phase === 'game-over'
+        ? 'Round finished. Lobby remains hidden while the result screen is shown.'
+        : 'Gameplay screen active. Lobby is fully hidden during the match.';
+  }
 }
 
 function renderGame(state, perSlotResult) {
-  panelEl.classList.add('gameplay-active');
-  gamePanelEl.classList.remove('hidden');
-  lobbyEl.classList.add('hidden');
+  showScreen('gameplay');
   gameRoomCodeEl.textContent = state.roomCode;
   ensureBoard(state.board.width, state.board.height);
   score0El.textContent = String(state.snakes[0].score);
@@ -183,6 +192,13 @@ function renderGame(state, perSlotResult) {
   }
 
   paintBoard(state);
+}
+
+function showScreen(screen) {
+  entryEl.classList.toggle('hidden', screen !== 'entry');
+  lobbyEl.classList.toggle('hidden', screen !== 'lobby');
+  gamePanelEl.classList.toggle('hidden', screen !== 'gameplay');
+  panelEl.classList.toggle('gameplay-active', screen === 'gameplay');
 }
 
 function ensureBoard(width, height) {

--- a/public/app.js
+++ b/public/app.js
@@ -20,11 +20,14 @@ const speedLabel = document.getElementById('speedLabel');
 const score0El = document.getElementById('score0');
 const score1El = document.getElementById('score1');
 const gameMessageEl = document.getElementById('gameMessage');
+const buildMarkerEl = document.getElementById('buildMarker');
 
 let latestLobbyState = null;
 let latestGameState = null;
 let yourSlotIndex = null;
 let boardReady = false;
+
+loadBuildMarker();
 
 socket.on('connect', () => {
   statusEl.textContent = 'Connected. Create a room or join with a code.';
@@ -130,6 +133,23 @@ document.addEventListener('keydown', (event) => {
   if (!direction || !latestGameState) return;
   socket.emit('player:direction:set', { direction });
 });
+
+async function loadBuildMarker() {
+  try {
+    const response = await fetch(`/build-info.json?ts=${Date.now()}`, { cache: 'no-store' });
+    if (!response.ok) {
+      throw new Error(`Build info request failed with ${response.status}`);
+    }
+
+    const buildInfo = await response.json();
+    buildMarkerEl.textContent = `Build: ${buildInfo.displayVersion}`;
+    buildMarkerEl.title = `Version ${buildInfo.version} • Commit ${buildInfo.commit} • Built ${buildInfo.builtAt}`;
+  } catch (error) {
+    console.error(error);
+    buildMarkerEl.textContent = 'Build: unavailable';
+    buildMarkerEl.title = 'Build metadata could not be loaded.';
+  }
+}
 
 function renderLobby(state) {
   roomCodeDisplay.textContent = state.roomCode;

--- a/public/app.js
+++ b/public/app.js
@@ -3,14 +3,25 @@ const socket = io();
 const statusEl = document.getElementById('status');
 const errorEl = document.getElementById('error');
 const lobbyEl = document.getElementById('lobby');
+const gamePanelEl = document.getElementById('gamePanel');
 const roomCodeInput = document.getElementById('roomCodeInput');
 const roomCodeDisplay = document.getElementById('roomCodeDisplay');
 const playersEl = document.getElementById('players');
 const readyButton = document.getElementById('readyButton');
 const lobbyMessage = document.getElementById('lobbyMessage');
 const phaseBadge = document.getElementById('phaseBadge');
+const boardEl = document.getElementById('board');
+const gamePhaseLabel = document.getElementById('gamePhaseLabel');
+const countdownLabel = document.getElementById('countdownLabel');
+const speedLabel = document.getElementById('speedLabel');
+const score0El = document.getElementById('score0');
+const score1El = document.getElementById('score1');
+const gameMessageEl = document.getElementById('gameMessage');
 
 let latestLobbyState = null;
+let latestGameState = null;
+let yourSlotIndex = null;
+let boardReady = false;
 
 socket.on('connect', () => {
   statusEl.textContent = 'Connected. Create a room or join with a code.';
@@ -21,28 +32,65 @@ socket.on('room:error', (payload) => {
   errorEl.classList.remove('hidden');
 });
 
-socket.on('room:created', () => {
+socket.on('room:created', (payload) => {
+  yourSlotIndex = payload.yourSlotIndex;
   errorEl.classList.add('hidden');
   statusEl.textContent = 'Room created.';
 });
 
-socket.on('room:joined', () => {
+socket.on('room:joined', (payload) => {
+  yourSlotIndex = payload.yourSlotIndex;
   errorEl.classList.add('hidden');
   statusEl.textContent = 'Joined room.';
 });
 
 socket.on('player:left', () => {
-  statusEl.textContent = 'A player left the lobby. Waiting for a replacement.';
+  statusEl.textContent = 'A player left. Waiting for a replacement.';
 });
 
 socket.on('lobby:state', (payload) => {
   latestLobbyState = payload;
+  if (payload.yourSlotIndex !== undefined) {
+    yourSlotIndex = payload.yourSlotIndex;
+  }
   renderLobby(payload);
 });
 
+socket.on('game:countdown', (payload) => {
+  statusEl.textContent = `Match starts in ${payload.secondsRemaining}...`;
+});
+
 socket.on('game:start', (payload) => {
-  statusEl.textContent = `Game started for room ${payload.roomCode}. Gameplay handoff placeholder reached.`;
-  readyButton.disabled = true;
+  statusEl.textContent = `Game started in room ${payload.roomCode}.`;
+  gamePhaseLabel.textContent = 'In progress';
+  countdownLabel.textContent = 'Countdown: go';
+  speedLabel.textContent = `Speed: ${payload.tickIntervalMs}ms`;
+});
+
+socket.on('game:state', (payload) => {
+  latestGameState = payload;
+  renderGame(payload);
+});
+
+socket.on('game:ended', (payload) => {
+  latestGameState = payload.finalState;
+  renderGame(payload.finalState, payload.result.bySlot);
+  const yourOutcome = yourSlotIndex === null ? 'draw' : payload.result.bySlot[yourSlotIndex];
+  statusEl.textContent = yourOutcome === 'win' ? 'You win!' : yourOutcome === 'lose' ? 'You lose.' : 'Round ended in a draw.';
+});
+
+socket.on('room:closed', (payload) => {
+  latestGameState = null;
+  latestLobbyState = null;
+  lobbyEl.classList.add('hidden');
+  gamePanelEl.classList.add('hidden');
+  boardEl.innerHTML = '';
+  boardReady = false;
+  roomCodeDisplay.textContent = '----';
+  phaseBadge.textContent = 'Closed';
+  statusEl.textContent = payload.reason === 'player-disconnected'
+    ? 'Room closed because a player disconnected. Create or join a new room to play again.'
+    : 'Room closed. Create or join a new room to play again.';
 });
 
 document.getElementById('createRoomButton').addEventListener('click', () => {
@@ -64,6 +112,12 @@ readyButton.addEventListener('click', () => {
   const you = latestLobbyState.players.find((player) => player.isYou);
   if (!you) return;
   socket.emit('player:ready:set', { ready: !you.isReady });
+});
+
+document.addEventListener('keydown', (event) => {
+  const direction = keyToDirection(event.key);
+  if (!direction || !latestGameState) return;
+  socket.emit('player:direction:set', { direction });
 });
 
 function renderLobby(state) {
@@ -88,5 +142,88 @@ function renderLobby(state) {
 
   const you = state.players.find((player) => player.isYou);
   readyButton.textContent = you?.isReady ? 'Unready' : 'Ready';
-  readyButton.disabled = !you || !you.isOccupied || state.phase === 'starting' || state.phase === 'in-progress';
+  readyButton.disabled = !you || !you.isOccupied || state.phase === 'starting' || state.phase === 'in-progress' || state.phase === 'game-over';
+}
+
+function renderGame(state, perSlotResult) {
+  gamePanelEl.classList.remove('hidden');
+  ensureBoard(state.board.width, state.board.height);
+  score0El.textContent = String(state.snakes[0].score);
+  score1El.textContent = String(state.snakes[1].score);
+  speedLabel.textContent = `Speed: ${state.tickIntervalMs}ms`;
+
+  if (state.phase === 'starting') {
+    gamePhaseLabel.textContent = 'Countdown';
+    countdownLabel.textContent = `Countdown: ${state.countdownSecondsRemaining ?? 3}`;
+    gameMessageEl.textContent = 'Queue your opening turn now. Snakes stay still until the countdown ends.';
+  } else if (state.phase === 'in-progress') {
+    gamePhaseLabel.textContent = 'In progress';
+    countdownLabel.textContent = `Tick: ${state.tickNumber}`;
+    gameMessageEl.textContent = 'Avoid walls, avoid bodies, and race for the shared food.';
+  } else {
+    gamePhaseLabel.textContent = 'Game over';
+    countdownLabel.textContent = 'Countdown: closed soon';
+    const yourOutcome = perSlotResult && yourSlotIndex !== null ? perSlotResult[yourSlotIndex] : 'draw';
+    gameMessageEl.textContent = yourOutcome === 'win' ? 'Result: you win.' : yourOutcome === 'lose' ? 'Result: you lose.' : 'Result: draw.';
+  }
+
+  paintBoard(state);
+}
+
+function ensureBoard(width, height) {
+  if (boardReady) return;
+  boardEl.innerHTML = '';
+  boardEl.style.gridTemplateColumns = `repeat(${width}, minmax(0, 1fr))`;
+  for (let i = 0; i < width * height; i += 1) {
+    const cell = document.createElement('div');
+    cell.className = 'cell';
+    boardEl.appendChild(cell);
+  }
+  boardReady = true;
+}
+
+function paintBoard(state) {
+  const cells = Array.from(boardEl.children);
+  for (const cell of cells) {
+    cell.className = 'cell';
+  }
+
+  paintCell(state.food.x, state.food.y, 'food', state.board.width);
+
+  state.snakes.forEach((snake) => {
+    snake.body.forEach((segment, index) => {
+      paintCell(segment.x, segment.y, `snake-${snake.slotIndex}`, state.board.width);
+      if (index === 0) {
+        paintCell(segment.x, segment.y, 'head', state.board.width);
+      }
+    });
+  });
+}
+
+function paintCell(x, y, className, width) {
+  const cell = boardEl.children[y * width + x];
+  if (cell) cell.classList.add(className);
+}
+
+function keyToDirection(key) {
+  switch (key) {
+    case 'ArrowUp':
+    case 'w':
+    case 'W':
+      return 'up';
+    case 'ArrowDown':
+    case 's':
+    case 'S':
+      return 'down';
+    case 'ArrowLeft':
+    case 'a':
+    case 'A':
+      return 'left';
+    case 'ArrowRight':
+    case 'd':
+    case 'D':
+      return 'right';
+    default:
+      return null;
+  }
 }

--- a/public/app.js
+++ b/public/app.js
@@ -3,6 +3,7 @@ const socket = io();
 const statusEl = document.getElementById('status');
 const errorEl = document.getElementById('error');
 const panelEl = document.querySelector('.panel');
+const panelTopEl = document.getElementById('panelTop');
 const entryEl = document.getElementById('entry');
 const lobbyEl = document.getElementById('lobby');
 const gamePanelEl = document.getElementById('gamePanel');
@@ -14,23 +15,27 @@ const readyButton = document.getElementById('readyButton');
 const lobbyMessage = document.getElementById('lobbyMessage');
 const phaseBadge = document.getElementById('phaseBadge');
 const boardEl = document.getElementById('board');
-const boardStatusBadgeEl = document.getElementById('boardStatusBadge');
 const gamePhaseLabel = document.getElementById('gamePhaseLabel');
+const gameStatusInlineEl = document.getElementById('gameStatusInline');
 const countdownLabel = document.getElementById('countdownLabel');
 const speedLabel = document.getElementById('speedLabel');
 const score0El = document.getElementById('score0');
 const score1El = document.getElementById('score1');
+const gameMessageEl = document.getElementById('gameMessage');
 const buildMarkerEl = document.getElementById('buildMarker');
+const gameBuildMarkerEl = document.getElementById('gameBuildMarker');
 
 let latestLobbyState = null;
 let latestGameState = null;
 let yourSlotIndex = null;
 let boardReady = false;
+let buildMarkerText = 'Build: loading…';
+let buildMarkerTitle = 'Build metadata is loading.';
 
 loadBuildMarker();
 
 socket.on('connect', () => {
-  setStatus('Connected. Create a room or join with a code.');
+  statusEl.textContent = 'Connected. Create a room or join with a code.';
   showScreen('entry');
 });
 
@@ -42,17 +47,18 @@ socket.on('room:error', (payload) => {
 socket.on('room:created', (payload) => {
   yourSlotIndex = payload.yourSlotIndex;
   errorEl.classList.add('hidden');
-  setStatus('Room created.');
+  statusEl.textContent = 'Room created.';
 });
 
 socket.on('room:joined', (payload) => {
   yourSlotIndex = payload.yourSlotIndex;
   errorEl.classList.add('hidden');
-  setStatus('Joined room.');
+  statusEl.textContent = 'Joined room.';
 });
 
 socket.on('player:left', () => {
-  setStatus('A player left. Waiting for a replacement.');
+  statusEl.textContent = 'A player left. Waiting for a replacement.';
+  gameStatusInlineEl.textContent = 'A player left. Waiting for a replacement.';
 });
 
 socket.on('lobby:state', (payload) => {
@@ -64,16 +70,18 @@ socket.on('lobby:state', (payload) => {
 });
 
 socket.on('game:countdown', (payload) => {
-  setStatus(`Match starts in ${payload.secondsRemaining}...`);
+  statusEl.textContent = `Match starts in ${payload.secondsRemaining}...`;
+  gameStatusInlineEl.textContent = `Match starts in ${payload.secondsRemaining}...`;
   showScreen('gameplay');
 });
 
 socket.on('game:start', (payload) => {
-  setStatus(`Game started in room ${payload.roomCode}.`);
+  statusEl.textContent = `Game started in room ${payload.roomCode}.`;
   gamePhaseLabel.textContent = 'In progress';
+  gameStatusInlineEl.textContent = 'Game live.';
   countdownLabel.textContent = 'Countdown: go';
   speedLabel.textContent = `Speed: ${payload.tickIntervalMs}ms`;
-  showBoardStatus('Go!');
+  gameMessageEl.textContent = 'Gameplay screen active. Lobby is fully hidden during the match.';
   showScreen('gameplay');
 });
 
@@ -86,7 +94,9 @@ socket.on('game:ended', (payload) => {
   latestGameState = payload.finalState;
   renderGame(payload.finalState, payload.result.bySlot);
   const yourOutcome = yourSlotIndex === null ? 'draw' : payload.result.bySlot[yourSlotIndex];
-  setStatus(yourOutcome === 'win' ? 'You win!' : yourOutcome === 'lose' ? 'You lose.' : 'Round ended in a draw.');
+  const statusText = yourOutcome === 'win' ? 'You win!' : yourOutcome === 'lose' ? 'You lose.' : 'Round ended in a draw.';
+  statusEl.textContent = statusText;
+  gameStatusInlineEl.textContent = statusText;
 });
 
 socket.on('room:closed', (payload) => {
@@ -97,11 +107,10 @@ socket.on('room:closed', (payload) => {
   roomCodeDisplay.textContent = '----';
   gameRoomCodeEl.textContent = '----';
   phaseBadge.textContent = 'Closed';
-  hideBoardStatus();
   showScreen('entry');
-  setStatus(payload.reason === 'player-disconnected'
+  statusEl.textContent = payload.reason === 'player-disconnected'
     ? 'Room closed because a player disconnected. Create or join a new room to play again.'
-    : 'Room closed. Create or join a new room to play again.');
+    : 'Room closed. Create or join a new room to play again.';
 });
 
 document.getElementById('createRoomButton').addEventListener('click', () => {
@@ -116,7 +125,11 @@ async function copyActiveRoomCode() {
   const roomCode = latestLobbyState?.roomCode || latestGameState?.roomCode;
   if (!roomCode) return;
   await navigator.clipboard.writeText(roomCode);
-  setStatus('Room code copied.');
+  const copiedText = 'Room code copied.';
+  statusEl.textContent = copiedText;
+  if (!gamePanelEl.classList.contains('hidden')) {
+    gameStatusInlineEl.textContent = copiedText;
+  }
 }
 
 document.getElementById('copyRoomCodeButton').addEventListener('click', copyActiveRoomCode);
@@ -143,13 +156,22 @@ async function loadBuildMarker() {
     }
 
     const buildInfo = await response.json();
-    buildMarkerEl.textContent = `Build: ${buildInfo.displayVersion}`;
-    buildMarkerEl.title = `Version ${buildInfo.version} • Commit ${buildInfo.commit} • Built ${buildInfo.builtAt}`;
+    buildMarkerText = `Build: ${buildInfo.displayVersion}`;
+    buildMarkerTitle = `Version ${buildInfo.version} • Commit ${buildInfo.commit} • Built ${buildInfo.builtAt}`;
   } catch (error) {
     console.error(error);
-    buildMarkerEl.textContent = 'Build: unavailable';
-    buildMarkerEl.title = 'Build metadata could not be loaded.';
+    buildMarkerText = 'Build: unavailable';
+    buildMarkerTitle = 'Build metadata could not be loaded.';
   }
+
+  syncBuildMarkers();
+}
+
+function syncBuildMarkers() {
+  buildMarkerEl.textContent = buildMarkerText;
+  buildMarkerEl.title = buildMarkerTitle;
+  gameBuildMarkerEl.textContent = buildMarkerText;
+  gameBuildMarkerEl.title = buildMarkerTitle;
 }
 
 function renderLobby(state) {
@@ -179,17 +201,19 @@ function renderLobby(state) {
   readyButton.textContent = you?.isReady ? 'Unready' : 'Ready';
   readyButton.disabled = !you || !you.isOccupied || state.phase === 'starting' || state.phase === 'in-progress' || state.phase === 'game-over';
 
-  if (!gameplayFocused) {
-    hideBoardStatus();
-    return;
+  if (gameplayFocused) {
+    gamePhaseLabel.textContent = state.phase === 'starting' ? 'Countdown' : state.phase === 'game-over' ? 'Game over' : 'In progress';
+    gameStatusInlineEl.textContent = state.phase === 'starting'
+      ? 'Match starts in moments.'
+      : state.phase === 'game-over'
+        ? 'Round complete.'
+        : 'Game live.';
+    gameMessageEl.textContent = state.phase === 'starting'
+      ? 'Both players are ready. Transitioning into gameplay.'
+      : state.phase === 'game-over'
+        ? 'Round finished. Lobby remains hidden while the result screen is shown.'
+        : 'Gameplay screen active. Lobby is fully hidden during the match.';
   }
-
-  gamePhaseLabel.textContent = state.phase === 'starting' ? 'Countdown' : state.phase === 'game-over' ? 'Game over' : 'In progress';
-  showBoardStatus(state.phase === 'starting'
-    ? 'Players ready'
-    : state.phase === 'game-over'
-      ? 'Round complete'
-      : 'Live match');
 }
 
 function renderGame(state, perSlotResult) {
@@ -202,41 +226,34 @@ function renderGame(state, perSlotResult) {
 
   if (state.phase === 'starting') {
     gamePhaseLabel.textContent = 'Countdown';
+    gameStatusInlineEl.textContent = 'Match starts in moments.';
     countdownLabel.textContent = `Countdown: ${state.countdownSecondsRemaining ?? 3}`;
-    showBoardStatus(`Match starts in ${state.countdownSecondsRemaining ?? 3}`);
+    gameMessageEl.textContent = 'Queue your opening turn now. Snakes stay still until the countdown ends.';
   } else if (state.phase === 'in-progress') {
     gamePhaseLabel.textContent = 'In progress';
+    gameStatusInlineEl.textContent = 'Game live.';
     countdownLabel.textContent = `Tick: ${state.tickNumber}`;
-    showBoardStatus('Live match');
+    gameMessageEl.textContent = 'Avoid walls, avoid bodies, and race for the shared food.';
   } else {
     gamePhaseLabel.textContent = 'Game over';
     countdownLabel.textContent = 'Countdown: closed soon';
     const yourOutcome = perSlotResult && yourSlotIndex !== null ? perSlotResult[yourSlotIndex] : 'draw';
-    showBoardStatus(yourOutcome === 'win' ? 'You win' : yourOutcome === 'lose' ? 'You lose' : 'Draw');
+    gameStatusInlineEl.textContent = yourOutcome === 'win' ? 'You win!' : yourOutcome === 'lose' ? 'You lose.' : 'Round ended in a draw.';
+    gameMessageEl.textContent = yourOutcome === 'win' ? 'Result: you win.' : yourOutcome === 'lose' ? 'Result: you lose.' : 'Result: draw.';
   }
 
   paintBoard(state);
 }
 
 function showScreen(screen) {
+  const gameplayActive = screen === 'gameplay';
   entryEl.classList.toggle('hidden', screen !== 'entry');
   lobbyEl.classList.toggle('hidden', screen !== 'lobby');
-  gamePanelEl.classList.toggle('hidden', screen !== 'gameplay');
-  panelEl.classList.toggle('gameplay-active', screen === 'gameplay');
-}
-
-function setStatus(message) {
-  statusEl.textContent = message;
-}
-
-function showBoardStatus(message) {
-  boardStatusBadgeEl.textContent = message;
-  boardStatusBadgeEl.classList.remove('hidden');
-}
-
-function hideBoardStatus() {
-  boardStatusBadgeEl.textContent = '';
-  boardStatusBadgeEl.classList.add('hidden');
+  gamePanelEl.classList.toggle('hidden', !gameplayActive);
+  panelEl.classList.toggle('gameplay-active', gameplayActive);
+  panelTopEl.classList.toggle('hidden', gameplayActive);
+  statusEl.classList.toggle('hidden', gameplayActive);
+  errorEl.classList.toggle('hidden', gameplayActive || !errorEl.textContent);
 }
 
 function ensureBoard(width, height) {

--- a/public/app.js
+++ b/public/app.js
@@ -14,12 +14,12 @@ const readyButton = document.getElementById('readyButton');
 const lobbyMessage = document.getElementById('lobbyMessage');
 const phaseBadge = document.getElementById('phaseBadge');
 const boardEl = document.getElementById('board');
+const boardStatusBadgeEl = document.getElementById('boardStatusBadge');
 const gamePhaseLabel = document.getElementById('gamePhaseLabel');
 const countdownLabel = document.getElementById('countdownLabel');
 const speedLabel = document.getElementById('speedLabel');
 const score0El = document.getElementById('score0');
 const score1El = document.getElementById('score1');
-const gameMessageEl = document.getElementById('gameMessage');
 const buildMarkerEl = document.getElementById('buildMarker');
 
 let latestLobbyState = null;
@@ -30,7 +30,7 @@ let boardReady = false;
 loadBuildMarker();
 
 socket.on('connect', () => {
-  statusEl.textContent = 'Connected. Create a room or join with a code.';
+  setStatus('Connected. Create a room or join with a code.');
   showScreen('entry');
 });
 
@@ -42,17 +42,17 @@ socket.on('room:error', (payload) => {
 socket.on('room:created', (payload) => {
   yourSlotIndex = payload.yourSlotIndex;
   errorEl.classList.add('hidden');
-  statusEl.textContent = 'Room created.';
+  setStatus('Room created.');
 });
 
 socket.on('room:joined', (payload) => {
   yourSlotIndex = payload.yourSlotIndex;
   errorEl.classList.add('hidden');
-  statusEl.textContent = 'Joined room.';
+  setStatus('Joined room.');
 });
 
 socket.on('player:left', () => {
-  statusEl.textContent = 'A player left. Waiting for a replacement.';
+  setStatus('A player left. Waiting for a replacement.');
 });
 
 socket.on('lobby:state', (payload) => {
@@ -64,16 +64,16 @@ socket.on('lobby:state', (payload) => {
 });
 
 socket.on('game:countdown', (payload) => {
-  statusEl.textContent = `Match starts in ${payload.secondsRemaining}...`;
+  setStatus(`Match starts in ${payload.secondsRemaining}...`);
   showScreen('gameplay');
 });
 
 socket.on('game:start', (payload) => {
-  statusEl.textContent = `Game started in room ${payload.roomCode}.`;
+  setStatus(`Game started in room ${payload.roomCode}.`);
   gamePhaseLabel.textContent = 'In progress';
   countdownLabel.textContent = 'Countdown: go';
   speedLabel.textContent = `Speed: ${payload.tickIntervalMs}ms`;
-  gameMessageEl.textContent = 'Gameplay screen active. Lobby is fully hidden during the match.';
+  showBoardStatus('Go!');
   showScreen('gameplay');
 });
 
@@ -86,7 +86,7 @@ socket.on('game:ended', (payload) => {
   latestGameState = payload.finalState;
   renderGame(payload.finalState, payload.result.bySlot);
   const yourOutcome = yourSlotIndex === null ? 'draw' : payload.result.bySlot[yourSlotIndex];
-  statusEl.textContent = yourOutcome === 'win' ? 'You win!' : yourOutcome === 'lose' ? 'You lose.' : 'Round ended in a draw.';
+  setStatus(yourOutcome === 'win' ? 'You win!' : yourOutcome === 'lose' ? 'You lose.' : 'Round ended in a draw.');
 });
 
 socket.on('room:closed', (payload) => {
@@ -97,10 +97,11 @@ socket.on('room:closed', (payload) => {
   roomCodeDisplay.textContent = '----';
   gameRoomCodeEl.textContent = '----';
   phaseBadge.textContent = 'Closed';
+  hideBoardStatus();
   showScreen('entry');
-  statusEl.textContent = payload.reason === 'player-disconnected'
+  setStatus(payload.reason === 'player-disconnected'
     ? 'Room closed because a player disconnected. Create or join a new room to play again.'
-    : 'Room closed. Create or join a new room to play again.';
+    : 'Room closed. Create or join a new room to play again.');
 });
 
 document.getElementById('createRoomButton').addEventListener('click', () => {
@@ -115,7 +116,7 @@ async function copyActiveRoomCode() {
   const roomCode = latestLobbyState?.roomCode || latestGameState?.roomCode;
   if (!roomCode) return;
   await navigator.clipboard.writeText(roomCode);
-  statusEl.textContent = 'Room code copied.';
+  setStatus('Room code copied.');
 }
 
 document.getElementById('copyRoomCodeButton').addEventListener('click', copyActiveRoomCode);
@@ -178,14 +179,17 @@ function renderLobby(state) {
   readyButton.textContent = you?.isReady ? 'Unready' : 'Ready';
   readyButton.disabled = !you || !you.isOccupied || state.phase === 'starting' || state.phase === 'in-progress' || state.phase === 'game-over';
 
-  if (gameplayFocused) {
-    gamePhaseLabel.textContent = state.phase === 'starting' ? 'Countdown' : state.phase === 'game-over' ? 'Game over' : 'In progress';
-    gameMessageEl.textContent = state.phase === 'starting'
-      ? 'Both players are ready. Transitioning into gameplay.'
-      : state.phase === 'game-over'
-        ? 'Round finished. Lobby remains hidden while the result screen is shown.'
-        : 'Gameplay screen active. Lobby is fully hidden during the match.';
+  if (!gameplayFocused) {
+    hideBoardStatus();
+    return;
   }
+
+  gamePhaseLabel.textContent = state.phase === 'starting' ? 'Countdown' : state.phase === 'game-over' ? 'Game over' : 'In progress';
+  showBoardStatus(state.phase === 'starting'
+    ? 'Players ready'
+    : state.phase === 'game-over'
+      ? 'Round complete'
+      : 'Live match');
 }
 
 function renderGame(state, perSlotResult) {
@@ -199,16 +203,16 @@ function renderGame(state, perSlotResult) {
   if (state.phase === 'starting') {
     gamePhaseLabel.textContent = 'Countdown';
     countdownLabel.textContent = `Countdown: ${state.countdownSecondsRemaining ?? 3}`;
-    gameMessageEl.textContent = 'Queue your opening turn now. Snakes stay still until the countdown ends.';
+    showBoardStatus(`Match starts in ${state.countdownSecondsRemaining ?? 3}`);
   } else if (state.phase === 'in-progress') {
     gamePhaseLabel.textContent = 'In progress';
     countdownLabel.textContent = `Tick: ${state.tickNumber}`;
-    gameMessageEl.textContent = 'Avoid walls, avoid bodies, and race for the shared food.';
+    showBoardStatus('Live match');
   } else {
     gamePhaseLabel.textContent = 'Game over';
     countdownLabel.textContent = 'Countdown: closed soon';
     const yourOutcome = perSlotResult && yourSlotIndex !== null ? perSlotResult[yourSlotIndex] : 'draw';
-    gameMessageEl.textContent = yourOutcome === 'win' ? 'Result: you win.' : yourOutcome === 'lose' ? 'Result: you lose.' : 'Result: draw.';
+    showBoardStatus(yourOutcome === 'win' ? 'You win' : yourOutcome === 'lose' ? 'You lose' : 'Draw');
   }
 
   paintBoard(state);
@@ -219,6 +223,20 @@ function showScreen(screen) {
   lobbyEl.classList.toggle('hidden', screen !== 'lobby');
   gamePanelEl.classList.toggle('hidden', screen !== 'gameplay');
   panelEl.classList.toggle('gameplay-active', screen === 'gameplay');
+}
+
+function setStatus(message) {
+  statusEl.textContent = message;
+}
+
+function showBoardStatus(message) {
+  boardStatusBadgeEl.textContent = message;
+  boardStatusBadgeEl.classList.remove('hidden');
+}
+
+function hideBoardStatus() {
+  boardStatusBadgeEl.textContent = '';
+  boardStatusBadgeEl.classList.add('hidden');
 }
 
 function ensureBoard(width, height) {

--- a/public/app.js
+++ b/public/app.js
@@ -2,10 +2,12 @@ const socket = io();
 
 const statusEl = document.getElementById('status');
 const errorEl = document.getElementById('error');
+const panelEl = document.querySelector('.panel');
 const lobbyEl = document.getElementById('lobby');
 const gamePanelEl = document.getElementById('gamePanel');
 const roomCodeInput = document.getElementById('roomCodeInput');
 const roomCodeDisplay = document.getElementById('roomCodeDisplay');
+const gameRoomCodeEl = document.getElementById('gameRoomCode');
 const playersEl = document.getElementById('players');
 const readyButton = document.getElementById('readyButton');
 const lobbyMessage = document.getElementById('lobbyMessage');
@@ -84,9 +86,11 @@ socket.on('room:closed', (payload) => {
   latestLobbyState = null;
   lobbyEl.classList.add('hidden');
   gamePanelEl.classList.add('hidden');
+  panelEl.classList.remove('gameplay-active');
   boardEl.innerHTML = '';
   boardReady = false;
   roomCodeDisplay.textContent = '----';
+  gameRoomCodeEl.textContent = '----';
   phaseBadge.textContent = 'Closed';
   statusEl.textContent = payload.reason === 'player-disconnected'
     ? 'Room closed because a player disconnected. Create or join a new room to play again.'
@@ -101,11 +105,15 @@ document.getElementById('joinRoomButton').addEventListener('click', () => {
   socket.emit('room:join', { roomCode: roomCodeInput.value });
 });
 
-document.getElementById('copyRoomCodeButton').addEventListener('click', async () => {
-  if (!latestLobbyState) return;
-  await navigator.clipboard.writeText(latestLobbyState.roomCode);
+async function copyActiveRoomCode() {
+  const roomCode = latestLobbyState?.roomCode || latestGameState?.roomCode;
+  if (!roomCode) return;
+  await navigator.clipboard.writeText(roomCode);
   statusEl.textContent = 'Room code copied.';
-});
+}
+
+document.getElementById('copyRoomCodeButton').addEventListener('click', copyActiveRoomCode);
+document.getElementById('copyGameRoomCodeButton').addEventListener('click', copyActiveRoomCode);
 
 readyButton.addEventListener('click', () => {
   if (!latestLobbyState) return;
@@ -121,8 +129,12 @@ document.addEventListener('keydown', (event) => {
 });
 
 function renderLobby(state) {
-  lobbyEl.classList.remove('hidden');
+  const gameplayFocused = state.phase === 'starting' || state.phase === 'in-progress' || state.phase === 'game-over';
+  lobbyEl.classList.toggle('hidden', gameplayFocused);
+  gamePanelEl.classList.toggle('hidden', !gameplayFocused && !latestGameState);
+  panelEl.classList.toggle('gameplay-active', gameplayFocused || Boolean(latestGameState));
   roomCodeDisplay.textContent = state.roomCode;
+  gameRoomCodeEl.textContent = state.roomCode;
   phaseBadge.textContent = state.phase;
   lobbyMessage.textContent = state.message || '';
   playersEl.innerHTML = '';
@@ -146,7 +158,10 @@ function renderLobby(state) {
 }
 
 function renderGame(state, perSlotResult) {
+  panelEl.classList.add('gameplay-active');
   gamePanelEl.classList.remove('hidden');
+  lobbyEl.classList.add('hidden');
+  gameRoomCodeEl.textContent = state.roomCode;
   ensureBoard(state.board.width, state.board.height);
   score0El.textContent = String(state.snakes[0].score);
   score1El.textContent = String(state.snakes[1].score);

--- a/public/index.html
+++ b/public/index.html
@@ -44,6 +44,13 @@
               <div class="eyebrow">Round</div>
               <div id="gamePhaseLabel" class="game-phase">Waiting</div>
             </div>
+            <div class="game-room-info">
+              <div>
+                <div class="eyebrow">Room code</div>
+                <div id="gameRoomCode" class="game-room-code">----</div>
+              </div>
+              <button id="copyGameRoomCodeButton" class="secondary-button" type="button">Copy code</button>
+            </div>
             <div class="scoreboard">
               <div class="score-card player-one">
                 <span>Player 1</span>

--- a/public/index.html
+++ b/public/index.html
@@ -9,8 +9,13 @@
   <body>
     <main class="app">
       <section class="panel">
-        <h1>Multiplayer Snake</h1>
-        <p class="subtitle">Create a room, share the code, ready up, then survive the round.</p>
+        <div class="panel-top">
+          <div>
+            <h1>Multiplayer Snake</h1>
+            <p class="subtitle">Create a room, share the code, ready up, then survive the round.</p>
+          </div>
+          <div id="buildMarker" class="build-marker" aria-live="polite">Build: loading…</div>
+        </div>
 
         <div id="status" class="status">Connecting…</div>
         <div id="error" class="error hidden"></div>

--- a/public/index.html
+++ b/public/index.html
@@ -3,14 +3,14 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Room Lobby Auto-Start</title>
+    <title>Multiplayer Snake</title>
     <link rel="stylesheet" href="/styles.css" />
   </head>
   <body>
     <main class="app">
       <section class="panel">
-        <h1>Multiplayer Snake Lobby</h1>
-        <p class="subtitle">Create a room, share the code, and the game starts automatically when both players are ready.</p>
+        <h1>Multiplayer Snake</h1>
+        <p class="subtitle">Create a room, share the code, ready up, then survive the round.</p>
 
         <div id="status" class="status">Connecting…</div>
         <div id="error" class="error hidden"></div>
@@ -37,6 +37,34 @@
           <button id="readyButton">Ready</button>
           <p id="lobbyMessage" class="message"></p>
         </div>
+
+        <section id="gamePanel" class="game hidden">
+          <div class="game-header">
+            <div>
+              <div class="eyebrow">Round</div>
+              <div id="gamePhaseLabel" class="game-phase">Waiting</div>
+            </div>
+            <div class="scoreboard">
+              <div class="score-card player-one">
+                <span>Player 1</span>
+                <strong id="score0">0</strong>
+              </div>
+              <div class="score-card player-two">
+                <span>Player 2</span>
+                <strong id="score1">0</strong>
+              </div>
+            </div>
+          </div>
+
+          <div class="game-meta">
+            <span id="countdownLabel">Countdown: --</span>
+            <span id="speedLabel">Speed: --</span>
+          </div>
+
+          <div id="board" class="board" aria-label="Game board"></div>
+          <p id="gameMessage" class="message"></p>
+          <p class="controls-hint">Use arrow keys or WASD during countdown and gameplay.</p>
+        </section>
       </section>
     </main>
 

--- a/public/index.html
+++ b/public/index.html
@@ -7,6 +7,11 @@
     <link rel="stylesheet" href="/styles.css" />
   </head>
   <body>
+    <div class="toast-stack" aria-live="polite" aria-atomic="true">
+      <div id="status" class="toast status">Connecting…</div>
+      <div id="error" class="toast error hidden"></div>
+    </div>
+
     <main class="app">
       <section class="panel">
         <div class="panel-top">
@@ -16,9 +21,6 @@
           </div>
           <div id="buildMarker" class="build-marker" aria-live="polite">Build: loading…</div>
         </div>
-
-        <div id="status" class="status">Connecting…</div>
-        <div id="error" class="error hidden"></div>
 
         <div id="entry" class="screen entry-screen">
           <div class="actions">
@@ -62,8 +64,10 @@
             </aside>
 
             <div class="game-center">
-              <div id="board" class="board" aria-label="Game board"></div>
-              <p id="gameMessage" class="message game-message"></p>
+              <div class="board-frame">
+                <div id="boardStatusBadge" class="board-status-badge hidden"></div>
+                <div id="board" class="board" aria-label="Game board"></div>
+              </div>
             </div>
 
             <aside class="game-side game-side-right">

--- a/public/index.html
+++ b/public/index.html
@@ -46,37 +46,47 @@
         </div>
 
         <section id="gamePanel" class="screen game hidden">
-          <div class="game-header">
-            <div>
-              <div class="eyebrow">Round</div>
-              <div id="gamePhaseLabel" class="game-phase">Waiting</div>
-            </div>
-            <div class="game-room-info">
-              <div>
-                <div class="eyebrow">Room code</div>
-                <div id="gameRoomCode" class="game-room-code">----</div>
+          <div class="game-shell">
+            <aside class="game-side game-side-left">
+              <div class="info-card">
+                <div class="eyebrow">Round</div>
+                <div id="gamePhaseLabel" class="game-phase">Waiting</div>
               </div>
-              <button id="copyGameRoomCodeButton" class="secondary-button" type="button">Copy code</button>
-            </div>
-            <div class="scoreboard">
-              <div class="score-card player-one">
-                <span>Player 1</span>
-                <strong id="score0">0</strong>
+              <div class="info-card">
+                <div class="eyebrow">Player 1</div>
+                <div class="score-card player-one solo-score-card">
+                  <span>Score</span>
+                  <strong id="score0">0</strong>
+                </div>
               </div>
-              <div class="score-card player-two">
-                <span>Player 2</span>
-                <strong id="score1">0</strong>
-              </div>
-            </div>
-          </div>
+            </aside>
 
-          <div class="game-meta">
-            <span id="countdownLabel">Countdown: --</span>
-            <span id="speedLabel">Speed: --</span>
-          </div>
+            <div class="game-center">
+              <div id="board" class="board" aria-label="Game board"></div>
+              <p id="gameMessage" class="message game-message"></p>
+            </div>
 
-          <div id="board" class="board" aria-label="Game board"></div>
-          <p id="gameMessage" class="message"></p>
+            <aside class="game-side game-side-right">
+              <div class="info-card room-info-card">
+                <div>
+                  <div class="eyebrow">Room code</div>
+                  <div id="gameRoomCode" class="game-room-code">----</div>
+                </div>
+                <button id="copyGameRoomCodeButton" class="secondary-button" type="button">Copy code</button>
+              </div>
+              <div class="info-card game-meta-stack">
+                <span id="countdownLabel">Countdown: --</span>
+                <span id="speedLabel">Speed: --</span>
+              </div>
+              <div class="info-card">
+                <div class="eyebrow">Player 2</div>
+                <div class="score-card player-two solo-score-card">
+                  <span>Score</span>
+                  <strong id="score1">0</strong>
+                </div>
+              </div>
+            </aside>
+          </div>
           <p class="controls-hint">Use arrow keys or WASD during countdown and gameplay.</p>
         </section>
       </section>

--- a/public/index.html
+++ b/public/index.html
@@ -15,15 +15,17 @@
         <div id="status" class="status">Connecting…</div>
         <div id="error" class="error hidden"></div>
 
-        <div class="actions">
-          <button id="createRoomButton">Create room</button>
-          <div class="join-row">
-            <input id="roomCodeInput" maxlength="6" placeholder="ROOM" />
-            <button id="joinRoomButton">Join room</button>
+        <div id="entry" class="screen entry-screen">
+          <div class="actions">
+            <button id="createRoomButton">Create room</button>
+            <div class="join-row">
+              <input id="roomCodeInput" maxlength="6" placeholder="ROOM" />
+              <button id="joinRoomButton">Join room</button>
+            </div>
           </div>
         </div>
 
-        <div id="lobby" class="lobby hidden">
+        <div id="lobby" class="screen lobby hidden">
           <div class="room-header">
             <div>
               <div class="eyebrow">Room code</div>
@@ -38,7 +40,7 @@
           <p id="lobbyMessage" class="message"></p>
         </div>
 
-        <section id="gamePanel" class="game hidden">
+        <section id="gamePanel" class="screen game hidden">
           <div class="game-header">
             <div>
               <div class="eyebrow">Round</div>

--- a/public/index.html
+++ b/public/index.html
@@ -7,20 +7,18 @@
     <link rel="stylesheet" href="/styles.css" />
   </head>
   <body>
-    <div class="toast-stack" aria-live="polite" aria-atomic="true">
-      <div id="status" class="toast status">Connecting…</div>
-      <div id="error" class="toast error hidden"></div>
-    </div>
-
     <main class="app">
       <section class="panel">
-        <div class="panel-top">
+        <div id="panelTop" class="panel-top">
           <div>
             <h1>Multiplayer Snake</h1>
             <p class="subtitle">Create a room, share the code, ready up, then survive the round.</p>
           </div>
           <div id="buildMarker" class="build-marker" aria-live="polite">Build: loading…</div>
         </div>
+
+        <div id="status" class="status">Connecting…</div>
+        <div id="error" class="error hidden"></div>
 
         <div id="entry" class="screen entry-screen">
           <div class="actions">
@@ -50,11 +48,12 @@
         <section id="gamePanel" class="screen game hidden">
           <div class="game-shell">
             <aside class="game-side game-side-left">
-              <div class="info-card">
-                <div class="eyebrow">Round</div>
+              <div class="info-card gameplay-summary-card">
+                <div class="eyebrow">Match</div>
                 <div id="gamePhaseLabel" class="game-phase">Waiting</div>
+                <p id="gameStatusInline" class="info-copy">Waiting for gameplay to begin.</p>
               </div>
-              <div class="info-card">
+              <div class="info-card compact-score-card">
                 <div class="eyebrow">Player 1</div>
                 <div class="score-card player-one solo-score-card">
                   <span>Score</span>
@@ -64,10 +63,8 @@
             </aside>
 
             <div class="game-center">
-              <div class="board-frame">
-                <div id="boardStatusBadge" class="board-status-badge hidden"></div>
-                <div id="board" class="board" aria-label="Game board"></div>
-              </div>
+              <div id="board" class="board" aria-label="Game board"></div>
+              <p id="gameMessage" class="message game-message"></p>
             </div>
 
             <aside class="game-side game-side-right">
@@ -81,8 +78,9 @@
               <div class="info-card game-meta-stack">
                 <span id="countdownLabel">Countdown: --</span>
                 <span id="speedLabel">Speed: --</span>
+                <span id="gameBuildMarker" class="inline-build-marker" aria-live="polite">Build: loading…</span>
               </div>
-              <div class="info-card">
+              <div class="info-card compact-score-card">
                 <div class="eyebrow">Player 2</div>
                 <div class="score-card player-two solo-score-card">
                   <span>Score</span>

--- a/public/styles.css
+++ b/public/styles.css
@@ -11,7 +11,7 @@ body { margin: 0; }
   min-height: 100vh;
   min-height: 100dvh;
   display: grid;
-  place-items: center;
+  place-items: start center;
   padding: var(--app-padding);
   box-sizing: border-box;
 }
@@ -22,19 +22,37 @@ body { margin: 0; }
   padding: var(--panel-padding);
   box-shadow: 0 16px 40px rgba(0,0,0,.35);
   box-sizing: border-box;
+  margin-top: 56px;
 }
 .panel.gameplay-active {
   width: min(100%, 1200px);
-  min-height: calc(100dvh - (var(--app-padding) * 2));
+  min-height: calc(100dvh - (var(--app-padding) * 2) - 56px);
   display: grid;
   align-content: start;
 }
 .panel-top { display: flex; justify-content: space-between; align-items: flex-start; gap: 16px; }
 h1 { margin: 0; }
 .subtitle,.message,.controls-hint { color: #cbd5e1; }
-.status,.error,.badge { margin: 10px 0; padding: 10px 12px; border-radius: 10px; }
-.status { background: #1d4ed8; }
-.error { background: #7f1d1d; }
+.toast-stack {
+  position: fixed;
+  top: 12px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: grid;
+  gap: 8px;
+  width: min(calc(100% - 24px), 560px);
+  z-index: 20;
+  pointer-events: none;
+}
+.toast,.badge {
+  padding: 10px 12px;
+  border-radius: 10px;
+}
+.toast {
+  box-shadow: 0 10px 30px rgba(0,0,0,.35);
+}
+.status { background: rgba(29, 78, 216, 0.92); }
+.error { background: rgba(127, 29, 29, 0.95); }
 .hidden { display: none !important; }
 .screen { margin-top: 16px; }
 .actions { display: grid; gap: 12px; }
@@ -101,6 +119,11 @@ button:disabled { opacity: .6; cursor: not-allowed; }
 .score-card strong { font-size: 24px; }
 .player-one { border-color: #22c55e; }
 .player-two { border-color: #38bdf8; }
+.board-frame {
+  position: relative;
+  width: min(100%, calc(100dvh - 180px), 680px);
+  max-width: 100%;
+}
 .board {
   display: grid;
   grid-template-columns: repeat(30, minmax(0, 1fr));
@@ -110,20 +133,33 @@ button:disabled { opacity: .6; cursor: not-allowed; }
   border-radius: 12px;
   padding: 1px;
   aspect-ratio: 1;
-  width: min(100%, calc(100dvh - 180px), 680px);
+  width: 100%;
   max-width: 100%;
   justify-self: center;
+}
+.board-status-badge {
+  position: absolute;
+  top: 12px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 2;
+  padding: 6px 10px;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.84);
+  border: 1px solid rgba(148, 163, 184, 0.45);
+  color: #f8fafc;
+  font-size: 12px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  backdrop-filter: blur(6px);
+  pointer-events: none;
+  white-space: nowrap;
 }
 .cell { background: #0f172a; aspect-ratio: 1; }
 .cell.food { background: #ef4444; }
 .cell.snake-0 { background: #22c55e; }
 .cell.snake-1 { background: #38bdf8; }
 .cell.head { box-shadow: inset 0 0 0 2px rgba(255,255,255,.35); }
-.game-message {
-  margin: 0;
-  text-align: center;
-  max-width: min(100%, 680px);
-}
 .build-marker {
   flex-shrink: 0;
   padding: 8px 10px;
@@ -141,7 +177,7 @@ button:disabled { opacity: .6; cursor: not-allowed; }
     gap: 12px;
   }
 
-  .board {
+  .board-frame {
     width: min(100%, calc(100dvh - 200px), 620px);
   }
 }
@@ -167,7 +203,7 @@ button:disabled { opacity: .6; cursor: not-allowed; }
     order: 3;
   }
 
-  .board {
+  .board-frame {
     width: min(100%, calc(100dvh - 250px), 620px);
   }
 }
@@ -193,11 +229,17 @@ button:disabled { opacity: .6; cursor: not-allowed; }
 
   .room-code,.game-room-code { font-size: 24px; }
   .game-phase { font-size: 20px; }
-  .board {
+  .board-frame {
     width: min(100%, calc(100dvh - 280px));
   }
 
   .build-marker {
     width: fit-content;
+  }
+
+  .board-status-badge {
+    max-width: calc(100% - 24px);
+    text-align: center;
+    white-space: normal;
   }
 }

--- a/public/styles.css
+++ b/public/styles.css
@@ -34,14 +34,15 @@ body { margin: 0; }
 .status { background: #1d4ed8; }
 .error { background: #7f1d1d; }
 .hidden { display: none !important; }
-.actions { display: grid; gap: 12px; margin-top: 20px; }
+.screen { margin-top: 20px; }
+.actions { display: grid; gap: 12px; }
 .join-row { display: flex; gap: 8px; }
 input,button { border-radius: 10px; border: 1px solid #334155; padding: 12px 14px; font: inherit; }
 input { flex: 1; background: #0f172a; color: #f9fafb; text-transform: uppercase; }
 button { cursor: pointer; background: #22c55e; color: #052e16; font-weight: 700; }
 button:disabled { opacity: .6; cursor: not-allowed; }
 .secondary-button { background: #0f172a; color: #f9fafb; }
-.lobby,.game { margin-top: 20px; display: grid; gap: 16px; }
+.lobby,.game { display: grid; gap: 16px; }
 .room-header,.game-header,.game-meta { display: flex; justify-content: space-between; align-items: center; gap: 12px; }
 .game-header { align-items: flex-end; flex-wrap: wrap; }
 .game-room-info { display: flex; align-items: center; gap: 12px; }

--- a/public/styles.css
+++ b/public/styles.css
@@ -3,8 +3,8 @@
   font-family: Inter, system-ui, sans-serif;
   background: #111827;
   color: #f9fafb;
-  --app-padding: 16px;
-  --panel-padding: 20px;
+  --app-padding: 12px;
+  --panel-padding: 16px;
 }
 body { margin: 0; }
 .app {
@@ -24,7 +24,7 @@ body { margin: 0; }
   box-sizing: border-box;
 }
 .panel.gameplay-active {
-  width: min(100%, 1120px);
+  width: min(100%, 1200px);
   min-height: calc(100dvh - (var(--app-padding) * 2));
   display: grid;
   align-content: start;
@@ -32,11 +32,11 @@ body { margin: 0; }
 .panel-top { display: flex; justify-content: space-between; align-items: flex-start; gap: 16px; }
 h1 { margin: 0; }
 .subtitle,.message,.controls-hint { color: #cbd5e1; }
-.status,.error,.badge { margin: 12px 0; padding: 10px 12px; border-radius: 10px; }
+.status,.error,.badge { margin: 10px 0; padding: 10px 12px; border-radius: 10px; }
 .status { background: #1d4ed8; }
 .error { background: #7f1d1d; }
 .hidden { display: none !important; }
-.screen { margin-top: 20px; }
+.screen { margin-top: 16px; }
 .actions { display: grid; gap: 12px; }
 .join-row { display: flex; gap: 8px; }
 input,button { border-radius: 10px; border: 1px solid #334155; padding: 12px 14px; font: inherit; }
@@ -45,9 +45,7 @@ button { cursor: pointer; background: #22c55e; color: #052e16; font-weight: 700;
 button:disabled { opacity: .6; cursor: not-allowed; }
 .secondary-button { background: #0f172a; color: #f9fafb; }
 .lobby,.game { display: grid; gap: 16px; }
-.room-header,.game-header,.game-meta { display: flex; justify-content: space-between; align-items: center; gap: 12px; }
-.game-header { align-items: flex-end; flex-wrap: wrap; }
-.game-room-info { display: flex; align-items: center; gap: 12px; }
+.room-header { display: flex; justify-content: space-between; align-items: center; gap: 12px; }
 .eyebrow { color: #94a3b8; font-size: 12px; text-transform: uppercase; letter-spacing: .08em; }
 .room-code,.game-room-code { font-size: 32px; font-weight: 800; letter-spacing: .14em; }
 .game-room-code { font-size: 24px; }
@@ -57,15 +55,52 @@ button:disabled { opacity: .6; cursor: not-allowed; }
 .player.you { border-color: #22c55e; }
 .player-meta { display: flex; justify-content: space-between; gap: 12px; }
 .player-state { color: #cbd5e1; margin-top: 8px; }
-.scoreboard { display: flex; gap: 12px; flex-wrap: wrap; }
-.score-card { min-width: 96px; background: #111827; border: 1px solid #334155; border-radius: 12px; padding: 10px 12px; display: grid; gap: 4px; }
+.game { align-content: start; gap: 12px; }
+.game-shell {
+  display: grid;
+  grid-template-columns: minmax(150px, 210px) minmax(0, 1fr) minmax(150px, 210px);
+  align-items: start;
+  gap: 16px;
+}
+.game-side,
+.game-center {
+  display: grid;
+  gap: 12px;
+  align-content: start;
+}
+.game-center {
+  justify-items: center;
+}
+.info-card {
+  background: #111827;
+  border: 1px solid #334155;
+  border-radius: 12px;
+  padding: 12px;
+  display: grid;
+  gap: 8px;
+}
+.room-info-card {
+  gap: 12px;
+}
+.game-meta-stack {
+  color: #cbd5e1;
+}
+.game-phase { font-size: 24px; font-weight: 700; }
+.score-card {
+  min-width: 96px;
+  background: #111827;
+  border: 1px solid #334155;
+  border-radius: 12px;
+  padding: 10px 12px;
+  display: grid;
+  gap: 4px;
+}
+.solo-score-card {
+  min-width: 0;
+}
 .score-card strong { font-size: 24px; }
 .player-one { border-color: #22c55e; }
 .player-two { border-color: #38bdf8; }
-.game-phase { font-size: 24px; font-weight: 700; }
-.game {
-  align-content: start;
-}
 .board {
   display: grid;
   grid-template-columns: repeat(30, minmax(0, 1fr));
@@ -75,7 +110,7 @@ button:disabled { opacity: .6; cursor: not-allowed; }
   border-radius: 12px;
   padding: 1px;
   aspect-ratio: 1;
-  width: min(100%, calc(100dvh - 320px));
+  width: min(100%, calc(100dvh - 180px), 680px);
   max-width: 100%;
   justify-self: center;
 }
@@ -84,6 +119,11 @@ button:disabled { opacity: .6; cursor: not-allowed; }
 .cell.snake-0 { background: #22c55e; }
 .cell.snake-1 { background: #38bdf8; }
 .cell.head { box-shadow: inset 0 0 0 2px rgba(255,255,255,.35); }
+.game-message {
+  margin: 0;
+  text-align: center;
+  max-width: min(100%, 680px);
+}
 .build-marker {
   flex-shrink: 0;
   padding: 8px 10px;
@@ -95,24 +135,66 @@ button:disabled { opacity: .6; cursor: not-allowed; }
   line-height: 1.2;
   letter-spacing: 0.02em;
 }
-@media (max-width: 900px) {
-  :root {
-    --app-padding: 12px;
-    --panel-padding: 16px;
+@media (max-width: 1100px) {
+  .game-shell {
+    grid-template-columns: minmax(136px, 180px) minmax(0, 1fr) minmax(136px, 180px);
+    gap: 12px;
   }
 
   .board {
-    width: min(100%, calc(100dvh - 360px));
+    width: min(100%, calc(100dvh - 200px), 620px);
+  }
+}
+@media (max-width: 860px) {
+  .game-shell {
+    grid-template-columns: 1fr;
+  }
+
+  .game-center {
+    order: 1;
+  }
+
+  .game-side-left,
+  .game-side-right {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .game-side-left {
+    order: 2;
+  }
+
+  .game-side-right {
+    order: 3;
+  }
+
+  .board {
+    width: min(100%, calc(100dvh - 250px), 620px);
   }
 }
 @media (max-width: 720px) {
-  .room-header,.game-header,.game-meta,.game-room-info,.panel-top { flex-direction: column; align-items: flex-start; }
-  .scoreboard { width: 100%; }
-  .score-card { flex: 1; }
+  .panel-top,
+  .room-header,
+  .game-side-left,
+  .game-side-right {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .panel-top,
+  .room-header {
+    display: flex;
+  }
+
+  .game-side-left,
+  .game-side-right {
+    display: grid;
+    grid-template-columns: 1fr;
+  }
+
   .room-code,.game-room-code { font-size: 24px; }
   .game-phase { font-size: 20px; }
   .board {
-    width: min(100%, calc(100dvh - 420px));
+    width: min(100%, calc(100dvh - 280px));
   }
 
   .build-marker {

--- a/public/styles.css
+++ b/public/styles.css
@@ -11,7 +11,7 @@ body { margin: 0; }
   min-height: 100vh;
   min-height: 100dvh;
   display: grid;
-  place-items: start center;
+  place-items: center;
   padding: var(--app-padding);
   box-sizing: border-box;
 }
@@ -22,37 +22,19 @@ body { margin: 0; }
   padding: var(--panel-padding);
   box-shadow: 0 16px 40px rgba(0,0,0,.35);
   box-sizing: border-box;
-  margin-top: 56px;
 }
 .panel.gameplay-active {
   width: min(100%, 1200px);
-  min-height: calc(100dvh - (var(--app-padding) * 2) - 56px);
+  min-height: calc(100dvh - (var(--app-padding) * 2));
   display: grid;
   align-content: start;
 }
 .panel-top { display: flex; justify-content: space-between; align-items: flex-start; gap: 16px; }
 h1 { margin: 0; }
-.subtitle,.message,.controls-hint { color: #cbd5e1; }
-.toast-stack {
-  position: fixed;
-  top: 12px;
-  left: 50%;
-  transform: translateX(-50%);
-  display: grid;
-  gap: 8px;
-  width: min(calc(100% - 24px), 560px);
-  z-index: 20;
-  pointer-events: none;
-}
-.toast,.badge {
-  padding: 10px 12px;
-  border-radius: 10px;
-}
-.toast {
-  box-shadow: 0 10px 30px rgba(0,0,0,.35);
-}
-.status { background: rgba(29, 78, 216, 0.92); }
-.error { background: rgba(127, 29, 29, 0.95); }
+.subtitle,.message,.controls-hint,.info-copy { color: #cbd5e1; }
+.status,.error,.badge { margin: 10px 0; padding: 10px 12px; border-radius: 10px; }
+.status { background: #1d4ed8; }
+.error { background: #7f1d1d; }
 .hidden { display: none !important; }
 .screen { margin-top: 16px; }
 .actions { display: grid; gap: 12px; }
@@ -73,10 +55,14 @@ button:disabled { opacity: .6; cursor: not-allowed; }
 .player.you { border-color: #22c55e; }
 .player-meta { display: flex; justify-content: space-between; gap: 12px; }
 .player-state { color: #cbd5e1; margin-top: 8px; }
-.game { align-content: start; gap: 12px; }
+.game {
+  margin-top: 0;
+  align-content: start;
+  gap: 12px;
+}
 .game-shell {
   display: grid;
-  grid-template-columns: minmax(150px, 210px) minmax(0, 1fr) minmax(150px, 210px);
+  grid-template-columns: minmax(180px, 220px) minmax(0, 1fr) minmax(180px, 220px);
   align-items: start;
   gap: 16px;
 }
@@ -97,6 +83,9 @@ button:disabled { opacity: .6; cursor: not-allowed; }
   display: grid;
   gap: 8px;
 }
+.gameplay-summary-card {
+  gap: 6px;
+}
 .room-info-card {
   gap: 12px;
 }
@@ -113,17 +102,15 @@ button:disabled { opacity: .6; cursor: not-allowed; }
   display: grid;
   gap: 4px;
 }
+.compact-score-card {
+  gap: 10px;
+}
 .solo-score-card {
   min-width: 0;
 }
 .score-card strong { font-size: 24px; }
 .player-one { border-color: #22c55e; }
 .player-two { border-color: #38bdf8; }
-.board-frame {
-  position: relative;
-  width: min(100%, calc(100dvh - 180px), 680px);
-  max-width: 100%;
-}
 .board {
   display: grid;
   grid-template-columns: repeat(30, minmax(0, 1fr));
@@ -133,35 +120,22 @@ button:disabled { opacity: .6; cursor: not-allowed; }
   border-radius: 12px;
   padding: 1px;
   aspect-ratio: 1;
-  width: 100%;
+  width: min(100%, calc(100dvh - 88px), 760px);
   max-width: 100%;
   justify-self: center;
-}
-.board-status-badge {
-  position: absolute;
-  top: 12px;
-  left: 50%;
-  transform: translateX(-50%);
-  z-index: 2;
-  padding: 6px 10px;
-  border-radius: 999px;
-  background: rgba(15, 23, 42, 0.84);
-  border: 1px solid rgba(148, 163, 184, 0.45);
-  color: #f8fafc;
-  font-size: 12px;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-  backdrop-filter: blur(6px);
-  pointer-events: none;
-  white-space: nowrap;
 }
 .cell { background: #0f172a; aspect-ratio: 1; }
 .cell.food { background: #ef4444; }
 .cell.snake-0 { background: #22c55e; }
 .cell.snake-1 { background: #38bdf8; }
 .cell.head { box-shadow: inset 0 0 0 2px rgba(255,255,255,.35); }
-.build-marker {
-  flex-shrink: 0;
+.game-message {
+  margin: 0;
+  text-align: center;
+  max-width: min(100%, 760px);
+}
+.build-marker,
+.inline-build-marker {
   padding: 8px 10px;
   border-radius: 999px;
   border: 1px solid #475569;
@@ -171,14 +145,20 @@ button:disabled { opacity: .6; cursor: not-allowed; }
   line-height: 1.2;
   letter-spacing: 0.02em;
 }
+.build-marker {
+  flex-shrink: 0;
+}
+.inline-build-marker {
+  width: fit-content;
+}
 @media (max-width: 1100px) {
   .game-shell {
-    grid-template-columns: minmax(136px, 180px) minmax(0, 1fr) minmax(136px, 180px);
+    grid-template-columns: minmax(156px, 190px) minmax(0, 1fr) minmax(156px, 190px);
     gap: 12px;
   }
 
-  .board-frame {
-    width: min(100%, calc(100dvh - 200px), 620px);
+  .board {
+    width: min(100%, calc(100dvh - 110px), 680px);
   }
 }
 @media (max-width: 860px) {
@@ -203,43 +183,31 @@ button:disabled { opacity: .6; cursor: not-allowed; }
     order: 3;
   }
 
-  .board-frame {
-    width: min(100%, calc(100dvh - 250px), 620px);
+  .board {
+    width: min(100%, calc(100dvh - 180px), 620px);
   }
 }
 @media (max-width: 720px) {
   .panel-top,
-  .room-header,
-  .game-side-left,
-  .game-side-right {
+  .room-header {
+    display: flex;
     flex-direction: column;
     align-items: flex-start;
   }
 
-  .panel-top,
-  .room-header {
-    display: flex;
-  }
-
   .game-side-left,
   .game-side-right {
-    display: grid;
     grid-template-columns: 1fr;
   }
 
   .room-code,.game-room-code { font-size: 24px; }
   .game-phase { font-size: 20px; }
-  .board-frame {
-    width: min(100%, calc(100dvh - 280px));
+  .board {
+    width: min(100%, calc(100dvh - 220px));
   }
 
-  .build-marker {
+  .build-marker,
+  .inline-build-marker {
     width: fit-content;
-  }
-
-  .board-status-badge {
-    max-width: calc(100% - 24px);
-    text-align: center;
-    white-space: normal;
   }
 }

--- a/public/styles.css
+++ b/public/styles.css
@@ -29,6 +29,8 @@ body { margin: 0; }
   display: grid;
   align-content: start;
 }
+.panel-top { display: flex; justify-content: space-between; align-items: flex-start; gap: 16px; }
+h1 { margin: 0; }
 .subtitle,.message,.controls-hint { color: #cbd5e1; }
 .status,.error,.badge { margin: 12px 0; padding: 10px 12px; border-radius: 10px; }
 .status { background: #1d4ed8; }
@@ -82,6 +84,17 @@ button:disabled { opacity: .6; cursor: not-allowed; }
 .cell.snake-0 { background: #22c55e; }
 .cell.snake-1 { background: #38bdf8; }
 .cell.head { box-shadow: inset 0 0 0 2px rgba(255,255,255,.35); }
+.build-marker {
+  flex-shrink: 0;
+  padding: 8px 10px;
+  border-radius: 999px;
+  border: 1px solid #475569;
+  background: #0f172a;
+  color: #cbd5e1;
+  font-size: 12px;
+  line-height: 1.2;
+  letter-spacing: 0.02em;
+}
 @media (max-width: 900px) {
   :root {
     --app-padding: 12px;
@@ -93,12 +106,16 @@ button:disabled { opacity: .6; cursor: not-allowed; }
   }
 }
 @media (max-width: 720px) {
-  .room-header,.game-header,.game-meta,.game-room-info { flex-direction: column; align-items: flex-start; }
+  .room-header,.game-header,.game-meta,.game-room-info,.panel-top { flex-direction: column; align-items: flex-start; }
   .scoreboard { width: 100%; }
   .score-card { flex: 1; }
   .room-code,.game-room-code { font-size: 24px; }
   .game-phase { font-size: 20px; }
   .board {
     width: min(100%, calc(100dvh - 420px));
+  }
+
+  .build-marker {
+    width: fit-content;
   }
 }

--- a/public/styles.css
+++ b/public/styles.css
@@ -3,10 +3,32 @@
   font-family: Inter, system-ui, sans-serif;
   background: #111827;
   color: #f9fafb;
+  --app-padding: 16px;
+  --panel-padding: 20px;
 }
 body { margin: 0; }
-.app { min-height: 100vh; display: grid; place-items: center; padding: 24px; }
-.panel { width: min(100%, 860px); background: #1f2937; border-radius: 16px; padding: 24px; box-shadow: 0 16px 40px rgba(0,0,0,.35); }
+.app {
+  min-height: 100vh;
+  min-height: 100dvh;
+  display: grid;
+  place-items: center;
+  padding: var(--app-padding);
+  box-sizing: border-box;
+}
+.panel {
+  width: min(100%, 860px);
+  background: #1f2937;
+  border-radius: 16px;
+  padding: var(--panel-padding);
+  box-shadow: 0 16px 40px rgba(0,0,0,.35);
+  box-sizing: border-box;
+}
+.panel.gameplay-active {
+  width: min(100%, 1120px);
+  min-height: calc(100dvh - (var(--app-padding) * 2));
+  display: grid;
+  align-content: start;
+}
 .subtitle,.message,.controls-hint { color: #cbd5e1; }
 .status,.error,.badge { margin: 12px 0; padding: 10px 12px; border-radius: 10px; }
 .status { background: #1d4ed8; }
@@ -18,23 +40,29 @@ input,button { border-radius: 10px; border: 1px solid #334155; padding: 12px 14p
 input { flex: 1; background: #0f172a; color: #f9fafb; text-transform: uppercase; }
 button { cursor: pointer; background: #22c55e; color: #052e16; font-weight: 700; }
 button:disabled { opacity: .6; cursor: not-allowed; }
+.secondary-button { background: #0f172a; color: #f9fafb; }
 .lobby,.game { margin-top: 20px; display: grid; gap: 16px; }
 .room-header,.game-header,.game-meta { display: flex; justify-content: space-between; align-items: center; gap: 12px; }
-.game-header { align-items: flex-end; }
+.game-header { align-items: flex-end; flex-wrap: wrap; }
+.game-room-info { display: flex; align-items: center; gap: 12px; }
 .eyebrow { color: #94a3b8; font-size: 12px; text-transform: uppercase; letter-spacing: .08em; }
-.room-code { font-size: 32px; font-weight: 800; letter-spacing: .14em; }
+.room-code,.game-room-code { font-size: 32px; font-weight: 800; letter-spacing: .14em; }
+.game-room-code { font-size: 24px; }
 .badge { background: #374151; width: fit-content; text-transform: capitalize; }
 .players { display: grid; gap: 12px; }
 .player { background: #111827; border: 1px solid #334155; border-radius: 12px; padding: 14px; }
 .player.you { border-color: #22c55e; }
 .player-meta { display: flex; justify-content: space-between; gap: 12px; }
 .player-state { color: #cbd5e1; margin-top: 8px; }
-.scoreboard { display: flex; gap: 12px; }
+.scoreboard { display: flex; gap: 12px; flex-wrap: wrap; }
 .score-card { min-width: 96px; background: #111827; border: 1px solid #334155; border-radius: 12px; padding: 10px 12px; display: grid; gap: 4px; }
 .score-card strong { font-size: 24px; }
 .player-one { border-color: #22c55e; }
 .player-two { border-color: #38bdf8; }
 .game-phase { font-size: 24px; font-weight: 700; }
+.game {
+  align-content: start;
+}
 .board {
   display: grid;
   grid-template-columns: repeat(30, minmax(0, 1fr));
@@ -44,15 +72,32 @@ button:disabled { opacity: .6; cursor: not-allowed; }
   border-radius: 12px;
   padding: 1px;
   aspect-ratio: 1;
+  width: min(100%, calc(100dvh - 320px));
+  max-width: 100%;
+  justify-self: center;
 }
 .cell { background: #0f172a; aspect-ratio: 1; }
 .cell.food { background: #ef4444; }
 .cell.snake-0 { background: #22c55e; }
 .cell.snake-1 { background: #38bdf8; }
 .cell.head { box-shadow: inset 0 0 0 2px rgba(255,255,255,.35); }
+@media (max-width: 900px) {
+  :root {
+    --app-padding: 12px;
+    --panel-padding: 16px;
+  }
+
+  .board {
+    width: min(100%, calc(100dvh - 360px));
+  }
+}
 @media (max-width: 720px) {
-  .panel { padding: 18px; }
-  .room-header,.game-header,.game-meta { flex-direction: column; align-items: flex-start; }
+  .room-header,.game-header,.game-meta,.game-room-info { flex-direction: column; align-items: flex-start; }
   .scoreboard { width: 100%; }
   .score-card { flex: 1; }
+  .room-code,.game-room-code { font-size: 24px; }
+  .game-phase { font-size: 20px; }
+  .board {
+    width: min(100%, calc(100dvh - 420px));
+  }
 }

--- a/public/styles.css
+++ b/public/styles.css
@@ -6,25 +6,53 @@
 }
 body { margin: 0; }
 .app { min-height: 100vh; display: grid; place-items: center; padding: 24px; }
-.panel { width: min(100%, 560px); background: #1f2937; border-radius: 16px; padding: 24px; box-shadow: 0 16px 40px rgba(0,0,0,.35); }
-.subtitle,.message { color: #cbd5e1; }
+.panel { width: min(100%, 860px); background: #1f2937; border-radius: 16px; padding: 24px; box-shadow: 0 16px 40px rgba(0,0,0,.35); }
+.subtitle,.message,.controls-hint { color: #cbd5e1; }
 .status,.error,.badge { margin: 12px 0; padding: 10px 12px; border-radius: 10px; }
 .status { background: #1d4ed8; }
 .error { background: #7f1d1d; }
-.hidden { display: none; }
+.hidden { display: none !important; }
 .actions { display: grid; gap: 12px; margin-top: 20px; }
 .join-row { display: flex; gap: 8px; }
 input,button { border-radius: 10px; border: 1px solid #334155; padding: 12px 14px; font: inherit; }
 input { flex: 1; background: #0f172a; color: #f9fafb; text-transform: uppercase; }
 button { cursor: pointer; background: #22c55e; color: #052e16; font-weight: 700; }
 button:disabled { opacity: .6; cursor: not-allowed; }
-.lobby { margin-top: 20px; display: grid; gap: 16px; }
-.room-header { display: flex; justify-content: space-between; align-items: center; gap: 12px; }
+.lobby,.game { margin-top: 20px; display: grid; gap: 16px; }
+.room-header,.game-header,.game-meta { display: flex; justify-content: space-between; align-items: center; gap: 12px; }
+.game-header { align-items: flex-end; }
 .eyebrow { color: #94a3b8; font-size: 12px; text-transform: uppercase; letter-spacing: .08em; }
 .room-code { font-size: 32px; font-weight: 800; letter-spacing: .14em; }
-.badge { background: #374151; width: fit-content; }
+.badge { background: #374151; width: fit-content; text-transform: capitalize; }
 .players { display: grid; gap: 12px; }
 .player { background: #111827; border: 1px solid #334155; border-radius: 12px; padding: 14px; }
 .player.you { border-color: #22c55e; }
 .player-meta { display: flex; justify-content: space-between; gap: 12px; }
 .player-state { color: #cbd5e1; margin-top: 8px; }
+.scoreboard { display: flex; gap: 12px; }
+.score-card { min-width: 96px; background: #111827; border: 1px solid #334155; border-radius: 12px; padding: 10px 12px; display: grid; gap: 4px; }
+.score-card strong { font-size: 24px; }
+.player-one { border-color: #22c55e; }
+.player-two { border-color: #38bdf8; }
+.game-phase { font-size: 24px; font-weight: 700; }
+.board {
+  display: grid;
+  grid-template-columns: repeat(30, minmax(0, 1fr));
+  gap: 1px;
+  background: #334155;
+  border: 1px solid #475569;
+  border-radius: 12px;
+  padding: 1px;
+  aspect-ratio: 1;
+}
+.cell { background: #0f172a; aspect-ratio: 1; }
+.cell.food { background: #ef4444; }
+.cell.snake-0 { background: #22c55e; }
+.cell.snake-1 { background: #38bdf8; }
+.cell.head { box-shadow: inset 0 0 0 2px rgba(255,255,255,.35); }
+@media (max-width: 720px) {
+  .panel { padding: 18px; }
+  .room-header,.game-header,.game-meta { flex-direction: column; align-items: flex-start; }
+  .scoreboard { width: 100%; }
+  .score-card { flex: 1; }
+}

--- a/src/server/__tests__/gameLogic.test.ts
+++ b/src/server/__tests__/gameLogic.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, test } from 'vitest';
+import { advanceOneTick, applyDisconnectResult, computeSpeedInterval, createInitialMatchState, queueDirectionInput, type MatchState } from '../gameLogic.js';
+
+function buildMatch(overrides: Partial<MatchState>): MatchState {
+  const base = createInitialMatchState('ROOM', () => 0);
+  return {
+    ...base,
+    ...overrides,
+    snakes: (overrides.snakes ?? base.snakes).map((snake) => ({ ...snake, body: snake.body.map((segment) => ({ ...segment })) })) as MatchState['snakes'],
+    food: overrides.food ?? base.food,
+  };
+}
+
+describe('gameLogic', () => {
+  test('queues one upcoming direction and blocks reversal against pending direction', () => {
+    const match = createInitialMatchState('ROOM');
+    const snake = match.snakes[0];
+
+    expect(queueDirectionInput(snake, 'up')).toBe(true);
+    expect(snake.pendingDirection).toBe('up');
+    expect(queueDirectionInput(snake, 'down')).toBe(false);
+    expect(snake.pendingDirection).toBe('up');
+  });
+
+  test('does not move snakes before gameplay starts and advances deterministically once active', () => {
+    const match = createInitialMatchState('ROOM', () => 0);
+    match.status = 'active';
+
+    const next = advanceOneTick(match, Date.now(), () => 0);
+    expect(next.tickNumber).toBe(1);
+    expect(next.snakes[0].body[0]).toEqual({ x: 8, y: 15 });
+    expect(next.snakes[1].body[0]).toEqual({ x: 21, y: 15 });
+  });
+
+  test('grows the consuming snake, increments score, and updates speed globally', () => {
+    const match = buildMatch({
+      status: 'active',
+      foodsEaten: 2,
+      food: { x: 8, y: 15 },
+    });
+
+    const next = advanceOneTick(match, Date.now(), () => 0);
+    expect(next.snakes[0].score).toBe(1);
+    expect(next.snakes[0].body).toHaveLength(4);
+    expect(next.foodsEaten).toBe(3);
+    expect(next.tickIntervalMs).toBe(170);
+  });
+
+  test('kills both snakes on same-cell head-to-head collision', () => {
+    const match = buildMatch({
+      status: 'active',
+      snakes: [
+        { slotIndex: 0, direction: 'right', pendingDirection: null, body: [{ x: 10, y: 10 }, { x: 9, y: 10 }, { x: 8, y: 10 }], alive: true, score: 0 },
+        { slotIndex: 1, direction: 'left', pendingDirection: null, body: [{ x: 12, y: 10 }, { x: 13, y: 10 }, { x: 14, y: 10 }], alive: true, score: 0 },
+      ],
+      food: { x: 0, y: 0 },
+    });
+
+    const next = advanceOneTick(match, Date.now(), () => 0);
+    expect(next.result).toBe('draw');
+    expect(next.deathReasons).toEqual([
+      { slotIndex: 0, reason: 'head-to-head' },
+      { slotIndex: 1, reason: 'head-to-head' },
+    ]);
+  });
+
+  test('kills both snakes on cross-over head swap', () => {
+    const match = buildMatch({
+      status: 'active',
+      snakes: [
+        { slotIndex: 0, direction: 'right', pendingDirection: null, body: [{ x: 10, y: 10 }, { x: 9, y: 10 }, { x: 8, y: 10 }], alive: true, score: 0 },
+        { slotIndex: 1, direction: 'left', pendingDirection: null, body: [{ x: 11, y: 10 }, { x: 12, y: 10 }, { x: 13, y: 10 }], alive: true, score: 0 },
+      ],
+      food: { x: 0, y: 0 },
+    });
+
+    const next = advanceOneTick(match, Date.now(), () => 0);
+    expect(next.result).toBe('draw');
+    expect(next.deathReasons).toEqual([
+      { slotIndex: 0, reason: 'cross-over' },
+      { slotIndex: 1, reason: 'cross-over' },
+    ]);
+  });
+
+  test('disconnect result awards the other player the win', () => {
+    const match = createInitialMatchState('ROOM');
+    const ended = applyDisconnectResult(match, 1, Date.now());
+
+    expect(ended.result).toBe('player-0-win');
+    expect(ended.winnerSlotIndex).toBe(0);
+    expect(ended.deathReasons).toEqual([{ slotIndex: 1, reason: 'disconnect' }]);
+  });
+
+  test('uses the bounded stepped speed schedule', () => {
+    expect(computeSpeedInterval(0)).toBe(200);
+    expect(computeSpeedInterval(3)).toBe(170);
+    expect(computeSpeedInterval(6)).toBe(140);
+    expect(computeSpeedInterval(9)).toBe(120);
+    expect(computeSpeedInterval(99)).toBe(120);
+  });
+});

--- a/src/server/__tests__/roomService.test.ts
+++ b/src/server/__tests__/roomService.test.ts
@@ -1,11 +1,16 @@
-import { describe, expect, test } from 'vitest';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { RoomService } from '../roomService.js';
 
-function payloads(result: ReturnType<RoomService['createRoom']> | ReturnType<RoomService['joinRoom']> | ReturnType<RoomService['setReady']> | ReturnType<RoomService['disconnect']>, type: string) {
+function payloads(result: { events: Array<{ type: string; payload: unknown }> }, type: string) {
   return result.events.filter((event) => event.type === type).map((event) => event.payload as any);
 }
 
 describe('RoomService', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-03-11T22:00:00Z'));
+  });
+
   test('creates a room and sends an authoritative one-player lobby state', () => {
     const service = new RoomService();
     const result = service.createRoom('socket-a');
@@ -20,45 +25,57 @@ describe('RoomService', () => {
     expect(lobbyState.players[1].isOccupied).toBe(false);
   });
 
-  test('joins a room, normalizes lowercase code, and starts only when both become ready', () => {
+  test('starts with a real countdown before emitting game start', () => {
+    const emitted: Array<{ type: string; payload: any }> = [];
     const service = new RoomService();
+    service.setEventSink((events) => emitted.push(...events));
+
     const created = service.createRoom('socket-a');
     const roomCode = payloads(created, 'room:created')[0].roomCode;
 
-    const joinResult = service.joinRoom('socket-b', roomCode.toLowerCase());
-    const joinLobbyStates = payloads(joinResult, 'lobby:state');
-    expect(joinLobbyStates).toHaveLength(2);
-    expect(joinLobbyStates[0].occupiedCount).toBe(2);
-    expect(joinLobbyStates[0].phase).toBe('lobby');
-
+    service.joinRoom('socket-b', roomCode.toLowerCase());
     expect(payloads(service.setReady('socket-a', true), 'game:start')).toHaveLength(0);
+
     const readyResult = service.setReady('socket-b', true);
-    const gameStartEvents = payloads(readyResult, 'game:start');
-    expect(gameStartEvents).toHaveLength(2);
-    expect(gameStartEvents[0].phase).toBe('in-progress');
+    expect(payloads(readyResult, 'game:start')).toHaveLength(0);
+    expect(payloads(readyResult, 'game:countdown')).toHaveLength(2);
+    expect(payloads(readyResult, 'game:state')[0].countdownSecondsRemaining).toBe(3);
+
+    vi.advanceTimersByTime(1000);
+    expect(emitted.filter((event) => event.type === 'game:countdown')).toHaveLength(2);
+    expect(emitted.filter((event) => event.type === 'game:countdown')[0].payload.secondsRemaining).toBe(2);
+
+    vi.advanceTimersByTime(1000);
+    expect(emitted.filter((event) => event.type === 'game:countdown')).toHaveLength(4);
+    expect(emitted.filter((event) => event.type === 'game:countdown')[2].payload.secondsRemaining).toBe(1);
+
+    vi.advanceTimersByTime(1000);
+    const gameStarts = emitted.filter((event) => event.type === 'game:start');
+    expect(gameStarts).toHaveLength(2);
+    expect(gameStarts[0].payload.phase).toBe('in-progress');
   });
 
-  test('rejects invalid code and third-player joins', () => {
+  test('disconnect during gameplay ends the round and closes the room', () => {
+    const emitted: Array<{ type: string; payload: any }> = [];
     const service = new RoomService();
-    expect(payloads(service.joinRoom('socket-a', '12'), 'room:error')[0].reason).toBe('INVALID_ROOM_CODE');
+    service.setEventSink((events) => emitted.push(...events));
 
-    const roomCode = payloads(service.createRoom('socket-a'), 'room:created')[0].roomCode;
-    service.joinRoom('socket-b', roomCode);
-    const fullError = payloads(service.joinRoom('socket-c', roomCode), 'room:error')[0];
-    expect(fullError.reason).toBe('ROOM_FULL');
-  });
-
-  test('resets remaining player readiness when occupancy drops below two', () => {
-    const service = new RoomService();
     const roomCode = payloads(service.createRoom('socket-a'), 'room:created')[0].roomCode;
     service.joinRoom('socket-b', roomCode);
     service.setReady('socket-a', true);
+    service.setReady('socket-b', true);
+    vi.advanceTimersByTime(3000);
 
     const disconnectResult = service.disconnect('socket-b');
-    const lobbyStateForRemainingPlayer = payloads(disconnectResult, 'lobby:state')[0];
-    expect(lobbyStateForRemainingPlayer.phase).toBe('waiting-for-players');
-    expect(lobbyStateForRemainingPlayer.occupiedCount).toBe(1);
-    expect(lobbyStateForRemainingPlayer.players[0].isReady).toBe(false);
-    expect(payloads(disconnectResult, 'game:start')).toHaveLength(0);
+    const ended = payloads(disconnectResult, 'game:ended');
+    expect(ended).toHaveLength(1);
+    expect(ended[0].result.winnerSlotIndex).toBe(0);
+    expect(ended[0].result.bySlot[0]).toBe('win');
+    expect(ended[0].result.bySlot[1]).toBe('lose');
+
+    vi.advanceTimersByTime(3000);
+    const roomClosed = emitted.filter((event) => event.type === 'room:closed');
+    expect(roomClosed).toHaveLength(1);
+    expect(roomClosed[0].payload.reason).toBe('player-disconnected');
   });
 });

--- a/src/server/gameLogic.ts
+++ b/src/server/gameLogic.ts
@@ -1,0 +1,282 @@
+export type Direction = 'up' | 'down' | 'left' | 'right';
+export type DeathReason = 'wall' | 'self' | 'head-to-head' | 'head-to-body' | 'cross-over' | 'disconnect';
+export type MatchStatus = 'countdown' | 'active' | 'ended';
+export type RoundResultKey = 'player-0-win' | 'player-1-win' | 'draw';
+
+export interface GridPoint {
+  x: number;
+  y: number;
+}
+
+export interface SnakeState {
+  slotIndex: 0 | 1;
+  direction: Direction;
+  pendingDirection: Direction | null;
+  body: GridPoint[];
+  alive: boolean;
+  score: number;
+}
+
+export interface MatchState {
+  roomCode: string;
+  board: { width: 30; height: 30 };
+  tickNumber: number;
+  status: MatchStatus;
+  snakes: [SnakeState, SnakeState];
+  food: GridPoint;
+  foodsEaten: number;
+  tickIntervalMs: number;
+  startedAt: number | null;
+  endedAt: number | null;
+  result: RoundResultKey | null;
+  deathReasons: Array<{ slotIndex: 0 | 1; reason: DeathReason }>;
+  winnerSlotIndex: 0 | 1 | null;
+}
+
+const BOARD = { width: 30, height: 30 } as const;
+const OPPOSITE: Record<Direction, Direction> = {
+  up: 'down',
+  down: 'up',
+  left: 'right',
+  right: 'left',
+};
+
+export function createInitialMatchState(roomCode: string, random: () => number = Math.random): MatchState {
+  const snakes: [SnakeState, SnakeState] = [
+    {
+      slotIndex: 0,
+      direction: 'right',
+      pendingDirection: null,
+      body: [
+        { x: 7, y: 15 },
+        { x: 6, y: 15 },
+        { x: 5, y: 15 },
+      ],
+      alive: true,
+      score: 0,
+    },
+    {
+      slotIndex: 1,
+      direction: 'left',
+      pendingDirection: null,
+      body: [
+        { x: 22, y: 15 },
+        { x: 23, y: 15 },
+        { x: 24, y: 15 },
+      ],
+      alive: true,
+      score: 0,
+    },
+  ];
+
+  const initialFood = spawnFood(BOARD, snakes, random);
+  if (!initialFood) {
+    throw new Error('Unable to spawn initial food on the board.');
+  }
+
+  return {
+    roomCode,
+    board: BOARD,
+    tickNumber: 0,
+    status: 'countdown',
+    snakes,
+    food: initialFood,
+    foodsEaten: 0,
+    tickIntervalMs: computeSpeedInterval(0),
+    startedAt: null,
+    endedAt: null,
+    result: null,
+    deathReasons: [],
+    winnerSlotIndex: null,
+  };
+}
+
+export function queueDirectionInput(snake: SnakeState, direction: Direction): boolean {
+  const effectiveDirection = snake.pendingDirection ?? snake.direction;
+  if (direction === effectiveDirection || OPPOSITE[effectiveDirection] === direction) {
+    return false;
+  }
+  snake.pendingDirection = direction;
+  return true;
+}
+
+export function computeSpeedInterval(foodsEaten: number): number {
+  if (foodsEaten >= 9) return 120;
+  if (foodsEaten >= 6) return 140;
+  if (foodsEaten >= 3) return 170;
+  return 200;
+}
+
+export function advanceOneTick(match: MatchState, now: number, random: () => number = Math.random): MatchState {
+  const snakes = match.snakes.map((snake) => ({
+    ...snake,
+    body: snake.body.map((segment) => ({ ...segment })),
+  })) as [SnakeState, SnakeState];
+
+  for (const snake of snakes) {
+    if (snake.pendingDirection) {
+      snake.direction = snake.pendingDirection;
+      snake.pendingDirection = null;
+    }
+  }
+
+  const candidateHeads = snakes.map((snake) => movePoint(snake.body[0], snake.direction)) as [GridPoint, GridPoint];
+  const consumers = candidateHeads.map((head) => samePoint(head, match.food)) as [boolean, boolean];
+
+  const candidateBodies = snakes.map((snake, index) => {
+    const nextBody = [candidateHeads[index], ...snake.body.map((segment) => ({ ...segment }))];
+    if (!consumers[index]) {
+      nextBody.pop();
+    }
+    return nextBody;
+  }) as [GridPoint[], GridPoint[]];
+
+  const deaths = new Map<0 | 1, DeathReason>();
+
+  snakes.forEach((snake, index) => {
+    const head = candidateHeads[index];
+    if (!isInsideBoard(head, match.board)) {
+      deaths.set(snake.slotIndex, 'wall');
+      return;
+    }
+
+    const ownBody = candidateBodies[index].slice(1);
+    if (ownBody.some((segment) => samePoint(segment, head))) {
+      deaths.set(snake.slotIndex, 'self');
+    }
+  });
+
+  const head0 = candidateHeads[0];
+  const head1 = candidateHeads[1];
+  if (samePoint(head0, head1)) {
+    deaths.set(0, deaths.get(0) ?? 'head-to-head');
+    deaths.set(1, deaths.get(1) ?? 'head-to-head');
+  }
+
+  if (samePoint(head0, match.snakes[1].body[0]) && samePoint(head1, match.snakes[0].body[0])) {
+    deaths.set(0, deaths.get(0) ?? 'cross-over');
+    deaths.set(1, deaths.get(1) ?? 'cross-over');
+  }
+
+  const body1 = candidateBodies[1].slice(1);
+  const body0 = candidateBodies[0].slice(1);
+  if (body1.some((segment) => samePoint(segment, head0))) {
+    deaths.set(0, deaths.get(0) ?? 'head-to-body');
+  }
+  if (body0.some((segment) => samePoint(segment, head1))) {
+    deaths.set(1, deaths.get(1) ?? 'head-to-body');
+  }
+
+  let foodsEaten = match.foodsEaten;
+  let food = { ...match.food };
+  const deathReasons = Array.from(deaths.entries()).map(([slotIndex, reason]) => ({ slotIndex, reason }));
+
+  for (const snake of snakes) {
+    const consumed = consumers[snake.slotIndex] && !deaths.has(snake.slotIndex);
+    snake.body = candidateBodies[snake.slotIndex];
+    snake.alive = !deaths.has(snake.slotIndex);
+    if (consumed) {
+      snake.score += 1;
+      foodsEaten += 1;
+    }
+  }
+
+  let result: RoundResultKey | null = null;
+  let winnerSlotIndex: 0 | 1 | null = null;
+  const aliveSnakes = snakes.filter((snake) => snake.alive);
+  if (aliveSnakes.length === 0) {
+    result = 'draw';
+  } else if (aliveSnakes.length === 1) {
+    winnerSlotIndex = aliveSnakes[0].slotIndex;
+    result = winnerSlotIndex === 0 ? 'player-0-win' : 'player-1-win';
+  }
+
+  if (!result && (consumers[0] || consumers[1])) {
+    const spawned = spawnFood(match.board, snakes, random);
+    if (spawned) {
+      food = spawned;
+    } else {
+      const score0 = snakes[0].score;
+      const score1 = snakes[1].score;
+      if (score0 === score1) {
+        result = 'draw';
+      } else {
+        winnerSlotIndex = score0 > score1 ? 0 : 1;
+        result = winnerSlotIndex === 0 ? 'player-0-win' : 'player-1-win';
+      }
+    }
+  }
+
+  return {
+    ...match,
+    status: result ? 'ended' : 'active',
+    tickNumber: match.tickNumber + 1,
+    snakes,
+    food,
+    foodsEaten,
+    tickIntervalMs: computeSpeedInterval(foodsEaten),
+    endedAt: result ? now : null,
+    result,
+    winnerSlotIndex,
+    deathReasons,
+  };
+}
+
+export function applyDisconnectResult(match: MatchState, slotIndex: 0 | 1, now: number): MatchState {
+  const snakes = match.snakes.map((snake) => ({ ...snake, body: snake.body.map((segment) => ({ ...segment })) })) as [SnakeState, SnakeState];
+  snakes[slotIndex].alive = false;
+  const otherIndex = slotIndex === 0 ? 1 : 0;
+  const otherConnectedAlive = snakes[otherIndex].alive;
+  const result = otherConnectedAlive ? (otherIndex === 0 ? 'player-0-win' : 'player-1-win') : 'draw';
+
+  return {
+    ...match,
+    status: 'ended',
+    snakes,
+    endedAt: now,
+    result,
+    winnerSlotIndex: otherConnectedAlive ? otherIndex : null,
+    deathReasons: [{ slotIndex, reason: 'disconnect' }],
+  };
+}
+
+export function toOutcomeForSlot(match: MatchState, slotIndex: 0 | 1): 'win' | 'lose' | 'draw' {
+  if (match.result === 'draw' || match.winnerSlotIndex === null) return 'draw';
+  return match.winnerSlotIndex === slotIndex ? 'win' : 'lose';
+}
+
+export function spawnFood(
+  board: { width: number; height: number },
+  snakes: Array<Pick<SnakeState, 'body'>>,
+  random: () => number = Math.random,
+): GridPoint | null {
+  const occupied = new Set(snakes.flatMap((snake) => snake.body.map((segment) => `${segment.x},${segment.y}`)));
+  const emptyCells: GridPoint[] = [];
+  for (let y = 0; y < board.height; y += 1) {
+    for (let x = 0; x < board.width; x += 1) {
+      if (!occupied.has(`${x},${y}`)) {
+        emptyCells.push({ x, y });
+      }
+    }
+  }
+
+  if (!emptyCells.length) return null;
+  return emptyCells[Math.floor(random() * emptyCells.length)] ?? null;
+}
+
+function movePoint(point: GridPoint, direction: Direction): GridPoint {
+  switch (direction) {
+    case 'up': return { x: point.x, y: point.y - 1 };
+    case 'down': return { x: point.x, y: point.y + 1 };
+    case 'left': return { x: point.x - 1, y: point.y };
+    case 'right': return { x: point.x + 1, y: point.y };
+  }
+}
+
+function isInsideBoard(point: GridPoint, board: { width: number; height: number }): boolean {
+  return point.x >= 0 && point.x < board.width && point.y >= 0 && point.y < board.height;
+}
+
+function samePoint(a: GridPoint, b: GridPoint): boolean {
+  return a.x === b.x && a.y === b.y;
+}

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,5 +1,6 @@
-import { createServer } from 'node:http';
+import { execSync } from 'node:child_process';
 import { readFileSync, existsSync } from 'node:fs';
+import { createServer } from 'node:http';
 import { extname, join } from 'node:path';
 import { Server } from 'socket.io';
 import { EVENTS, type Direction } from '../shared/contracts.js';
@@ -7,6 +8,7 @@ import { RoomService, type ClientEvent } from './roomService.js';
 
 const publicDir = join(process.cwd(), 'public');
 const roomService = new RoomService();
+const buildInfo = resolveBuildInfo();
 
 const mimeTypes: Record<string, string> = {
   '.html': 'text/html; charset=utf-8',
@@ -15,7 +17,18 @@ const mimeTypes: Record<string, string> = {
 };
 
 const httpServer = createServer((req, res) => {
-  const urlPath = req.url === '/' ? '/index.html' : req.url || '/index.html';
+  const url = new URL(req.url || '/', 'http://localhost');
+
+  if (url.pathname === '/build-info.json') {
+    res.writeHead(200, {
+      'Content-Type': 'application/json; charset=utf-8',
+      'Cache-Control': 'no-store, max-age=0',
+    });
+    res.end(JSON.stringify(buildInfo));
+    return;
+  }
+
+  const urlPath = url.pathname === '/' ? '/index.html' : url.pathname;
   const filePath = join(publicDir, urlPath.replace(/^\//, ''));
 
   if (!filePath.startsWith(publicDir) || !existsSync(filePath)) {
@@ -24,7 +37,10 @@ const httpServer = createServer((req, res) => {
     return;
   }
 
-  res.writeHead(200, { 'Content-Type': mimeTypes[extname(filePath)] || 'application/octet-stream' });
+  res.writeHead(200, {
+    'Content-Type': mimeTypes[extname(filePath)] || 'application/octet-stream',
+    'Cache-Control': urlPath === '/index.html' ? 'no-store, max-age=0' : 'public, max-age=3600',
+  });
   res.end(readFileSync(filePath));
 });
 
@@ -62,7 +78,32 @@ function emitEvents(events: ClientEvent[] | { events: ClientEvent[] }) {
   }
 }
 
+function resolveBuildInfo() {
+  const packageJson = JSON.parse(readFileSync(join(process.cwd(), 'package.json'), 'utf8')) as { version?: string };
+  const version = packageJson.version || '0.0.0';
+  const commit = readGitValue('git rev-parse --short HEAD') || 'unknown';
+  const builtAt = process.env.BUILD_TIMESTAMP || new Date().toISOString();
+
+  return {
+    version,
+    commit,
+    builtAt,
+    displayVersion: `v${version}+${commit}`,
+  };
+}
+
+function readGitValue(command: string) {
+  try {
+    return execSync(command, {
+      cwd: process.cwd(),
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).toString().trim();
+  } catch {
+    return '';
+  }
+}
+
 const port = Number(process.env.PORT || 3000);
 httpServer.listen(port, () => {
-  console.log(`Room lobby server listening on http://localhost:${port}`);
+  console.log(`Room lobby server listening on http://localhost:${port} (${buildInfo.displayVersion})`);
 });

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -2,7 +2,7 @@ import { createServer } from 'node:http';
 import { readFileSync, existsSync } from 'node:fs';
 import { extname, join } from 'node:path';
 import { Server } from 'socket.io';
-import { EVENTS } from '../shared/contracts.js';
+import { EVENTS, type Direction } from '../shared/contracts.js';
 import { RoomService, type ClientEvent } from './roomService.js';
 
 const publicDir = join(process.cwd(), 'public');
@@ -28,9 +28,8 @@ const httpServer = createServer((req, res) => {
   res.end(readFileSync(filePath));
 });
 
-const io = new Server(httpServer, {
-  cors: { origin: '*' },
-});
+const io = new Server(httpServer, { cors: { origin: '*' } });
+roomService.setEventSink(emitEvents);
 
 io.on('connection', (socket) => {
   socket.on(EVENTS.roomCreate, () => {
@@ -42,10 +41,13 @@ io.on('connection', (socket) => {
   });
 
   socket.on(EVENTS.playerReadySet, (payload: { ready?: boolean }) => {
-    if (typeof payload?.ready !== 'boolean') {
-      return;
-    }
+    if (typeof payload?.ready !== 'boolean') return;
     emitEvents(roomService.setReady(socket.id, payload.ready).events);
+  });
+
+  socket.on(EVENTS.playerDirectionSet, (payload: { direction?: Direction }) => {
+    if (!payload?.direction || !['up', 'down', 'left', 'right'].includes(payload.direction)) return;
+    emitEvents(roomService.setDirection(socket.id, payload.direction));
   });
 
   socket.on('disconnect', () => {
@@ -53,8 +55,9 @@ io.on('connection', (socket) => {
   });
 });
 
-function emitEvents(events: ClientEvent[]) {
-  for (const event of events) {
+function emitEvents(events: ClientEvent[] | { events: ClientEvent[] }) {
+  const list = Array.isArray(events) ? events : events.events;
+  for (const event of list) {
     io.to(event.socketId).emit(event.type, event.payload);
   }
 }

--- a/src/server/roomService.ts
+++ b/src/server/roomService.ts
@@ -1,12 +1,25 @@
 import type {
+  Direction,
+  GameCountdownPayload,
+  GameEndedPayload,
   GameStartPayload,
+  GameStatePayload,
   LobbyErrorReason,
   LobbyStatePayload,
   PlayerLeftPayload,
+  RoomClosedPayload,
   RoomCreatedPayload,
   RoomJoinedPayload,
   RoomPhase,
 } from '../shared/contracts.js';
+import {
+  applyDisconnectResult,
+  advanceOneTick,
+  createInitialMatchState,
+  queueDirectionInput,
+  toOutcomeForSlot,
+  type MatchState,
+} from './gameLogic.js';
 
 interface PlayerSlot {
   slotIndex: 0 | 1;
@@ -22,11 +35,23 @@ interface RoomRecord {
   createdAt: number;
   players: [PlayerSlot, PlayerSlot];
   version: number;
-  startNonce: number;
+  match: MatchState | null;
+  countdown: { startedAt: number; endsAt: number; secondsRemaining: 3 | 2 | 1 | 0 } | null;
+  teardownAt: number | null;
 }
 
 export interface ClientEvent {
-  type: 'room:created' | 'room:joined' | 'lobby:state' | 'room:error' | 'player:left' | 'game:start';
+  type:
+    | 'room:created'
+    | 'room:joined'
+    | 'lobby:state'
+    | 'room:error'
+    | 'player:left'
+    | 'game:countdown'
+    | 'game:start'
+    | 'game:state'
+    | 'game:ended'
+    | 'room:closed';
   socketId: string;
   payload: unknown;
 }
@@ -35,11 +60,23 @@ export interface ServiceResult {
   events: ClientEvent[];
 }
 
+interface RuntimeRecord {
+  countdownTimers: NodeJS.Timeout[];
+  tickTimer: NodeJS.Timeout | null;
+  teardownTimer: NodeJS.Timeout | null;
+}
+
 export class RoomService {
   private readonly rooms = new Map<string, RoomRecord>();
+  private readonly runtimes = new Map<string, RuntimeRecord>();
   private readonly socketToRoom = new Map<string, string>();
   private readonly socketToPlayer = new Map<string, string>();
   private nextPlayerId = 1;
+  private emitExternal: (events: ClientEvent[]) => void = () => {};
+
+  setEventSink(emitExternal: (events: ClientEvent[]) => void) {
+    this.emitExternal = emitExternal;
+  }
 
   createRoom(socketId: string): ServiceResult {
     this.leaveCurrentRoom(socketId, 'left');
@@ -51,7 +88,9 @@ export class RoomService {
       phase: 'waiting-for-players',
       createdAt: Date.now(),
       version: 1,
-      startNonce: 0,
+      match: null,
+      countdown: null,
+      teardownAt: null,
       players: [
         { slotIndex: 0, playerId, socketId, connected: true, ready: false },
         { slotIndex: 1, playerId: null, socketId: null, connected: false, ready: false },
@@ -74,23 +113,16 @@ export class RoomService {
     this.leaveCurrentRoom(socketId, 'left');
 
     const roomCode = this.normalizeRoomCode(rawRoomCode);
-    if (!this.isValidRoomCode(roomCode)) {
-      return { events: [this.error(socketId, 'INVALID_ROOM_CODE')] };
-    }
+    if (!this.isValidRoomCode(roomCode)) return { events: [this.error(socketId, 'INVALID_ROOM_CODE')] };
 
     const room = this.rooms.get(roomCode);
-    if (!room) {
-      return { events: [this.error(socketId, 'ROOM_NOT_FOUND')] };
-    }
-
-    if (room.phase === 'starting' || room.phase === 'in-progress') {
+    if (!room) return { events: [this.error(socketId, 'ROOM_NOT_FOUND')] };
+    if (room.phase === 'starting' || room.phase === 'in-progress' || room.phase === 'game-over') {
       return { events: [this.error(socketId, 'GAME_ALREADY_STARTED')] };
     }
 
     const emptySlot = room.players.find((player) => !player.playerId);
-    if (!emptySlot) {
-      return { events: [this.error(socketId, 'ROOM_FULL')] };
-    }
+    if (!emptySlot) return { events: [this.error(socketId, 'ROOM_FULL')] };
 
     const playerId = this.allocatePlayerId();
     emptySlot.playerId = playerId;
@@ -105,7 +137,7 @@ export class RoomService {
     return {
       events: [
         { type: 'room:joined', socketId, payload: { roomCode, yourSlotIndex: emptySlot.slotIndex } satisfies RoomJoinedPayload },
-        ...this.afterMutation(room),
+        ...this.afterLobbyMutation(room),
       ],
     };
   }
@@ -117,15 +149,26 @@ export class RoomService {
     }
 
     const player = room.players.find((slot) => slot.socketId === socketId);
-    if (!player) {
-      return { events: [this.error(socketId, 'ACTION_NOT_ALLOWED')] };
-    }
+    if (!player) return { events: [this.error(socketId, 'ACTION_NOT_ALLOWED')] };
 
     player.ready = ready;
     room.version += 1;
     room.phase = this.computePhase(room);
 
-    return { events: this.afterMutation(room) };
+    return { events: this.afterLobbyMutation(room) };
+  }
+
+  setDirection(socketId: string, direction: Direction): ServiceResult {
+    const room = this.getRoomForSocket(socketId);
+    if (!room || !room.match || (room.phase !== 'starting' && room.phase !== 'in-progress')) {
+      return { events: [this.error(socketId, 'ACTION_NOT_ALLOWED')] };
+    }
+
+    const player = room.players.find((slot) => slot.socketId === socketId);
+    if (!player) return { events: [this.error(socketId, 'ACTION_NOT_ALLOWED')] };
+
+    const queued = queueDirectionInput(room.match.snakes[player.slotIndex], direction);
+    return queued ? { events: [] } : { events: [this.error(socketId, 'ACTION_NOT_ALLOWED')] };
   }
 
   disconnect(socketId: string): ServiceResult {
@@ -134,22 +177,15 @@ export class RoomService {
 
   private leaveCurrentRoom(socketId: string, reason: 'left' | 'disconnected'): ServiceResult {
     const roomCode = this.socketToRoom.get(socketId);
-    if (!roomCode) {
-      return { events: [] };
-    }
+    if (!roomCode) return { events: [] };
 
     const room = this.rooms.get(roomCode);
     this.socketToRoom.delete(socketId);
     this.socketToPlayer.delete(socketId);
-
-    if (!room) {
-      return { events: [] };
-    }
+    if (!room) return { events: [] };
 
     const leavingPlayer = room.players.find((slot) => slot.socketId === socketId);
-    if (!leavingPlayer) {
-      return { events: [] };
-    }
+    if (!leavingPlayer) return { events: [] };
 
     const slotIndex = leavingPlayer.slotIndex;
     leavingPlayer.playerId = null;
@@ -158,65 +194,182 @@ export class RoomService {
     leavingPlayer.ready = false;
 
     const remainingPlayers = room.players.filter((slot) => slot.playerId);
-    if (remainingPlayers.length === 1) {
-      remainingPlayers[0].ready = false;
-    }
-
     if (remainingPlayers.length === 0) {
-      this.rooms.delete(roomCode);
+      this.disposeRoom(roomCode);
       return { events: [] };
     }
 
+    if (room.phase === 'starting' || room.phase === 'in-progress') {
+      const events = this.finishMatch(room, applyDisconnectResult(room.match!, slotIndex, Date.now()), reason === 'disconnected' ? 'player-disconnected' : 'round-complete');
+      return { events };
+    }
+
+    remainingPlayers[0].ready = false;
     room.version += 1;
     room.phase = 'waiting-for-players';
 
     const events: ClientEvent[] = remainingPlayers.flatMap((slot) => [
-      {
-        type: 'player:left',
-        socketId: slot.socketId!,
-        payload: { roomCode, slotIndex, reason } satisfies PlayerLeftPayload,
-      },
+      { type: 'player:left', socketId: slot.socketId!, payload: { roomCode, slotIndex, reason } satisfies PlayerLeftPayload },
     ]);
-
     events.push(...this.buildLobbyStateEvents(room));
     return { events };
   }
 
-  private afterMutation(room: RoomRecord): ClientEvent[] {
+  private afterLobbyMutation(room: RoomRecord): ClientEvent[] {
     const events = this.buildLobbyStateEvents(room);
+    if (!this.canStart(room)) return events;
 
-    if (!this.canStart(room)) {
-      return events;
-    }
-
-    room.startNonce += 1;
     room.phase = 'starting';
     room.version += 1;
+    room.match = createInitialMatchState(room.roomCode);
+    const now = Date.now();
+    room.countdown = { startedAt: now, endsAt: now + 3000, secondsRemaining: 3 };
     events.push(...this.buildLobbyStateEvents(room));
+    events.push(...this.buildGameStateEvents(room, 3));
+    events.push(...this.buildCountdownEvents(room, 3, now));
 
-    if (!this.canStart(room)) {
-      room.phase = this.computePhase(room);
-      room.version += 1;
-      events.push(...this.buildLobbyStateEvents(room));
-      return events;
-    }
+    this.startCountdown(room.roomCode);
+    return events;
+  }
 
+  private startCountdown(roomCode: string) {
+    this.cancelRuntime(roomCode);
+    const runtime: RuntimeRecord = { countdownTimers: [], tickTimer: null, teardownTimer: null };
+    const room = this.rooms.get(roomCode);
+    if (!room || !room.countdown) return;
+
+    ([2, 1, 0] as const).forEach((second, index) => {
+      const timer = setTimeout(() => {
+        const activeRoom = this.rooms.get(roomCode);
+        if (!activeRoom || activeRoom.phase !== 'starting' || !activeRoom.countdown || !activeRoom.match) return;
+        activeRoom.countdown.secondsRemaining = second;
+        activeRoom.version += 1;
+        const now = Date.now();
+        const events: ClientEvent[] = [
+          ...this.buildLobbyStateEvents(activeRoom),
+          ...this.buildGameStateEvents(activeRoom, second),
+          ...this.buildCountdownEvents(activeRoom, second, now),
+        ];
+        if (second === 0) {
+          events.push(...this.beginActiveMatch(activeRoom, now));
+        }
+        this.emitExternal(events);
+      }, (index + 1) * 1000);
+      runtime.countdownTimers.push(timer);
+    });
+
+    this.runtimes.set(roomCode, runtime);
+  }
+
+  private beginActiveMatch(room: RoomRecord, now: number): ClientEvent[] {
+    if (!room.match) return [];
     room.phase = 'in-progress';
     room.version += 1;
-    const gameStartPayload: GameStartPayload = {
+    room.countdown = null;
+    room.match.status = 'active';
+    room.match.startedAt = now;
+    const payload: GameStartPayload = {
       roomCode: room.roomCode,
       phase: 'in-progress',
+      board: room.match.board,
       players: [
         { slotIndex: 0, label: 'Player 1' },
         { slotIndex: 1, label: 'Player 2' },
       ],
+      tickIntervalMs: room.match.tickIntervalMs,
+      startedAt: now,
+      version: room.version,
     };
+    const events = this.buildLobbyStateEvents(room);
     for (const player of room.players) {
-      if (player.socketId) {
-        events.push({ type: 'game:start', socketId: player.socketId, payload: gameStartPayload });
-      }
+      if (player.socketId) events.push({ type: 'game:start', socketId: player.socketId, payload });
     }
+    this.scheduleNextTick(room.roomCode, room.match.tickIntervalMs);
     return events;
+  }
+
+  private scheduleNextTick(roomCode: string, delayMs: number) {
+    const runtime = this.runtimes.get(roomCode);
+    if (!runtime) return;
+    runtime.tickTimer = setTimeout(() => {
+      const room = this.rooms.get(roomCode);
+      if (!room || room.phase !== 'in-progress' || !room.match) return;
+      room.match = advanceOneTick(room.match, Date.now());
+      room.version += 1;
+      if (room.match.result) {
+        this.emitExternal(this.finishMatch(room, room.match, 'round-complete'));
+        return;
+      }
+      this.emitExternal(this.buildGameStateEvents(room));
+      this.scheduleNextTick(roomCode, room.match.tickIntervalMs);
+    }, delayMs);
+  }
+
+  private finishMatch(room: RoomRecord, match: MatchState, closeReason: 'round-complete' | 'player-disconnected'): ClientEvent[] {
+    room.match = match;
+    room.phase = 'game-over';
+    room.version += 1;
+    room.teardownAt = Date.now() + 3000;
+    this.cancelRuntime(room.roomCode);
+
+    const finalState = this.serializeGameState(room);
+    const payload: GameEndedPayload = {
+      roomCode: room.roomCode,
+      phase: 'game-over',
+      result: {
+        bySlot: {
+          0: toOutcomeForSlot(match, 0),
+          1: toOutcomeForSlot(match, 1),
+        },
+        winnerSlotIndex: match.winnerSlotIndex,
+        deathReasons: match.deathReasons,
+      },
+      finalState,
+      teardownAt: room.teardownAt,
+      version: room.version,
+    };
+
+    const events = this.buildLobbyStateEvents(room);
+    events.push(...this.buildGameStateEvents(room));
+    for (const player of room.players) {
+      if (player.socketId) events.push({ type: 'game:ended', socketId: player.socketId, payload });
+    }
+
+    const runtime: RuntimeRecord = { countdownTimers: [], tickTimer: null, teardownTimer: null };
+    runtime.teardownTimer = setTimeout(() => {
+      const activeRoom = this.rooms.get(room.roomCode);
+      if (!activeRoom) return;
+      const closeEvents: ClientEvent[] = [];
+      for (const player of activeRoom.players) {
+        if (!player.socketId) continue;
+        closeEvents.push({
+          type: 'room:closed',
+          socketId: player.socketId,
+          payload: { roomCode: activeRoom.roomCode, reason: closeReason, version: activeRoom.version } satisfies RoomClosedPayload,
+        });
+        this.socketToRoom.delete(player.socketId);
+        this.socketToPlayer.delete(player.socketId);
+      }
+      this.disposeRoom(activeRoom.roomCode);
+      this.emitExternal(closeEvents);
+    }, 3000);
+    this.runtimes.set(room.roomCode, runtime);
+
+    return events;
+  }
+
+  private cancelRuntime(roomCode: string) {
+    const existing = this.runtimes.get(roomCode);
+    if (!existing) return;
+    for (const timer of existing.countdownTimers) clearTimeout(timer);
+    if (existing.tickTimer) clearTimeout(existing.tickTimer);
+    if (existing.teardownTimer) clearTimeout(existing.teardownTimer);
+    this.runtimes.delete(roomCode);
+  }
+
+  private disposeRoom(roomCode: string) {
+    this.cancelRuntime(roomCode);
+    this.rooms.delete(roomCode);
   }
 
   private buildLobbyStateEvents(room: RoomRecord): ClientEvent[] {
@@ -224,6 +377,25 @@ export class RoomService {
       if (!player.socketId) return [];
       return [{ type: 'lobby:state' as const, socketId: player.socketId, payload: this.serializeLobbyState(room, player.socketId) }];
     });
+  }
+
+  private buildCountdownEvents(room: RoomRecord, secondsRemaining: 3 | 2 | 1 | 0, now: number): ClientEvent[] {
+    if (!room.countdown) return [];
+    const payload: GameCountdownPayload = {
+      roomCode: room.roomCode,
+      phase: 'starting',
+      secondsRemaining,
+      startsAt: room.countdown.startedAt,
+      serverNow: now,
+      version: room.version,
+    };
+    return room.players.flatMap((player) => (player.socketId ? [{ type: 'game:countdown' as const, socketId: player.socketId, payload }] : []));
+  }
+
+  private buildGameStateEvents(room: RoomRecord, countdownSecondsRemaining?: 3 | 2 | 1 | 0): ClientEvent[] {
+    if (!room.match) return [];
+    const payload = this.serializeGameState(room, countdownSecondsRemaining);
+    return room.players.flatMap((player) => (player.socketId ? [{ type: 'game:state' as const, socketId: player.socketId, payload }] : []));
   }
 
   private serializeLobbyState(room: RoomRecord, viewerSocketId: string): LobbyStatePayload {
@@ -247,12 +419,50 @@ export class RoomService {
       allReady,
       canStart,
       version: room.version,
-      message: allPlayersPresent ? 'Game starts automatically when both players are ready.' : 'Waiting for opponent.',
+      message: this.getLobbyMessage(room),
     };
   }
 
+  private serializeGameState(room: RoomRecord, countdownSecondsRemaining?: 3 | 2 | 1 | 0): GameStatePayload {
+    const match = room.match!;
+    return {
+      roomCode: room.roomCode,
+      phase: room.phase === 'game-over' ? 'game-over' : room.phase === 'starting' ? 'starting' : 'in-progress',
+      tickNumber: match.tickNumber,
+      board: match.board,
+      food: match.food,
+      snakes: match.snakes.map((snake) => ({
+        slotIndex: snake.slotIndex,
+        body: snake.body,
+        direction: snake.direction,
+        alive: snake.alive,
+        score: snake.score,
+      })) as GameStatePayload['snakes'],
+      foodsEaten: match.foodsEaten,
+      tickIntervalMs: match.tickIntervalMs,
+      countdownSecondsRemaining,
+      result: room.phase === 'game-over'
+        ? {
+            outcome: match.result === 'draw' ? 'draw' : match.winnerSlotIndex === 0 ? 'win' : 'lose',
+            winnerSlotIndex: match.winnerSlotIndex,
+            deathReasons: match.deathReasons,
+          }
+        : undefined,
+      version: room.version,
+    };
+  }
+
+  private getLobbyMessage(room: RoomRecord): string {
+    if (room.phase === 'starting' && room.countdown) return `Match starts in ${room.countdown.secondsRemaining}…`;
+    if (room.phase === 'in-progress') return 'Match in progress.';
+    if (room.phase === 'game-over') return 'Round complete. Room will close shortly.';
+    return room.players.filter((player) => player.playerId).length === 2
+      ? 'Game starts automatically when both players are ready.'
+      : 'Waiting for opponent.';
+  }
+
   private canStart(room: RoomRecord): boolean {
-    return room.phase !== 'in-progress' && room.players.every((player) => player.playerId && player.connected && player.ready);
+    return !room.match && room.players.every((player) => player.playerId && player.connected && player.ready);
   }
 
   private computePhase(room: RoomRecord): RoomPhase {
@@ -296,10 +506,6 @@ export class RoomService {
       ACTION_NOT_ALLOWED: 'That action is not available right now.',
     };
 
-    return {
-      type: 'room:error',
-      socketId,
-      payload: { reason, message: messages[reason] },
-    };
+    return { type: 'room:error', socketId, payload: { reason, message: messages[reason] } };
   }
 }

--- a/src/shared/contracts.ts
+++ b/src/shared/contracts.ts
@@ -1,4 +1,7 @@
-export type RoomPhase = 'waiting-for-players' | 'lobby' | 'starting' | 'in-progress';
+export type RoomPhase = 'waiting-for-players' | 'lobby' | 'starting' | 'in-progress' | 'game-over';
+export type Direction = 'up' | 'down' | 'left' | 'right';
+export type RoundResult = 'win' | 'lose' | 'draw';
+export type DeathReason = 'wall' | 'self' | 'head-to-head' | 'head-to-body' | 'cross-over' | 'disconnect';
 
 export type LobbyErrorReason =
   | 'INVALID_ROOM_CODE'
@@ -6,6 +9,11 @@ export type LobbyErrorReason =
   | 'ROOM_FULL'
   | 'GAME_ALREADY_STARTED'
   | 'ACTION_NOT_ALLOWED';
+
+export interface GridPoint {
+  x: number;
+  y: number;
+}
 
 export interface LobbyPlayerView {
   slotIndex: 0 | 1;
@@ -25,6 +33,35 @@ export interface LobbyStatePayload {
   canStart: boolean;
   version: number;
   message?: string;
+}
+
+export interface PublicSnakeState {
+  slotIndex: 0 | 1;
+  body: GridPoint[];
+  direction: Direction;
+  alive: boolean;
+  score: number;
+}
+
+export interface PublicGameStatePayload {
+  roomCode: string;
+  phase: 'starting' | 'in-progress' | 'game-over';
+  tickNumber: number;
+  board: {
+    width: 30;
+    height: 30;
+  };
+  food: GridPoint;
+  snakes: [PublicSnakeState, PublicSnakeState];
+  foodsEaten: number;
+  tickIntervalMs: number;
+  countdownSecondsRemaining?: 3 | 2 | 1 | 0;
+  result?: {
+    outcome: RoundResult;
+    winnerSlotIndex: 0 | 1 | null;
+    deathReasons: Array<{ slotIndex: 0 | 1; reason: DeathReason }>;
+  };
+  version: number;
 }
 
 export interface RoomCreatedPayload {
@@ -48,13 +85,57 @@ export interface PlayerLeftPayload {
   reason: 'left' | 'disconnected';
 }
 
+export interface PlayerDirectionSetPayload {
+  direction: Direction;
+}
+
+export interface GameCountdownPayload {
+  roomCode: string;
+  phase: 'starting';
+  secondsRemaining: 3 | 2 | 1 | 0;
+  startsAt: number;
+  serverNow: number;
+  version: number;
+}
+
 export interface GameStartPayload {
   roomCode: string;
   phase: 'in-progress';
+  board: {
+    width: 30;
+    height: 30;
+  };
   players: [
-    { slotIndex: 0 | 1; label: 'Player 1' | 'Player 2' },
-    { slotIndex: 0 | 1; label: 'Player 1' | 'Player 2' }
+    { slotIndex: 0; label: 'Player 1' },
+    { slotIndex: 1; label: 'Player 2' }
   ];
+  tickIntervalMs: number;
+  startedAt: number;
+  version: number;
+}
+
+export type GameStatePayload = PublicGameStatePayload;
+
+export interface GameEndedPayload {
+  roomCode: string;
+  phase: 'game-over';
+  result: {
+    bySlot: {
+      0: RoundResult;
+      1: RoundResult;
+    };
+    winnerSlotIndex: 0 | 1 | null;
+    deathReasons: Array<{ slotIndex: 0 | 1; reason: DeathReason }>;
+  };
+  finalState: PublicGameStatePayload;
+  teardownAt: number;
+  version: number;
+}
+
+export interface RoomClosedPayload {
+  roomCode: string;
+  reason: 'round-complete' | 'player-disconnected';
+  version: number;
 }
 
 export const EVENTS = {
@@ -66,5 +147,10 @@ export const EVENTS = {
   lobbyState: 'lobby:state',
   playerReadySet: 'player:ready:set',
   playerLeft: 'player:left',
+  playerDirectionSet: 'player:direction:set',
+  gameCountdown: 'game:countdown',
   gameStart: 'game:start',
+  gameState: 'game:state',
+  gameEnded: 'game:ended',
+  roomClosed: 'room:closed',
 } as const;


### PR DESCRIPTION
## Summary
- add a server-authoritative gameplay runtime with real countdown, tick scheduling, collision resolution, speed progression, and room teardown
- extend shared contracts and browser UI so players can see the board, control their snake, and receive result/room-close events
- add gameplay and room-service tests plus implementation notes for issue #10

## Testing
- npm test
- npm run build

Closes #10