### PR TITLE
feat: implement replay / rematch flow

### DIFF
--- a/.trace/architect.md
+++ b/.trace/architect.md
@@ -96,3 +96,47 @@ If resuming this agent from branch state:
 - Check issue labels for current workflow state.
 - Read the latest PR comments for context.
 - Do NOT reload the full codebase — only files referenced in this trace.
+
+# Architect Trace
+
+## Phase
+Issue #13 architecture design
+
+## Timestamp
+2026-03-12T00:20:34Z
+
+## Input
+- Issue: #13
+- Trigger: PM handoff for architecture phase
+- Key artifacts read: GitHub issue #13, docs/impl/replay-rematch-flow/spec.md, src/shared/contracts.ts, src/server/roomService.ts, existing docs under docs/impl/room-lobby-autostart/ and docs/impl/core-gameplay-loop/
+
+## Decisions
+1. Decision: Keep  as the top-level room phase and represent rematch with a dedicated rematch sub-state.
+   Rationale: Minimizes churn and avoids inventing a parallel lifecycle for post-game flow.
+2. Decision: Remove automatic room teardown after normal round completion and keep the room open for same-room replay.
+   Rationale: The feature requires rematch in the same room with the same code.
+3. Decision: Clear both rematch acceptances whenever room membership changes after game over.
+   Rationale: Prevents stale dual-acceptance state from carrying across disconnect/leave or replacement-player scenarios.
+4. Decision: Use a dedicated  intent and  snapshot while allowing rematch state to also appear in authoritative room/game payloads.
+   Rationale: Keeps client and QA visibility explicit without replacing existing socket flows.
+
+## Actions Taken
+1. Prepared architect checkout on  and reviewed the current room/gameplay implementation. → Confirmed current forced post-game teardown is the main behavior to change.
+2. Wrote . → Captured state transitions, reset semantics, leave behavior, and implementation order.
+3. Wrote . → Defined rematch socket events, payload additions, semantics, and test assertions.
+
+## Outputs
+- : architecture design for same-room rematch flow
+- : socket contracts and payload semantics for rematch
+
+## Handoff
+- Next agent: fullstack-dev
+- Trigger: Architecture design complete
+- Context needed: Read , , , plus current , , and result-screen client handling in 
+
+## Resume Point
+If resuming this agent from branch state:
+- Read this trace file first.
+- Check issue labels for current workflow state.
+- Read the latest PR comments for context.
+- Do NOT reload the full codebase — only files referenced in this trace.

--- a/.trace/architect.md
+++ b/.trace/architect.md
@@ -111,13 +111,13 @@ Issue #13 architecture design
 - Key artifacts read: GitHub issue #13, docs/impl/replay-rematch-flow/spec.md, src/shared/contracts.ts, src/server/roomService.ts, existing docs under docs/impl/room-lobby-autostart/ and docs/impl/core-gameplay-loop/
 
 ## Decisions
-1. Decision: Keep  as the top-level room phase and represent rematch with a dedicated rematch sub-state.
+1. Decision: Keep `game-over` as the top-level room phase and represent rematch with a dedicated rematch sub-state.
    Rationale: Minimizes churn and avoids inventing a parallel lifecycle for post-game flow.
 2. Decision: Remove automatic room teardown after normal round completion and keep the room open for same-room replay.
    Rationale: The feature requires rematch in the same room with the same code.
 3. Decision: Clear both rematch acceptances whenever room membership changes after game over.
    Rationale: Prevents stale dual-acceptance state from carrying across disconnect/leave or replacement-player scenarios.
-4. Decision: Use a dedicated  intent and  snapshot while allowing rematch state to also appear in authoritative room/game payloads.
+4. Decision: Use a dedicated `game:rematch-request` intent and `game:rematch-state` snapshot while allowing rematch state to also appear in authoritative room/game payloads.
    Rationale: Keeps client and QA visibility explicit without replacing existing socket flows.
 
 ## Actions Taken
@@ -132,7 +132,7 @@ Issue #13 architecture design
 ## Handoff
 - Next agent: fullstack-dev
 - Trigger: Architecture design complete
-- Context needed: Read , , , plus current , , and result-screen client handling in 
+- Context needed: Read `docs/impl/replay-rematch-flow/spec.md`, `design.md`, `api-contracts.md`, plus current `src/server/roomService.ts`, `src/shared/contracts.ts`, and result-screen client handling in `public/app.js`
 
 ## Resume Point
 If resuming this agent from branch state:

--- a/.trace/architect.md
+++ b/.trace/architect.md
@@ -121,13 +121,13 @@ Issue #13 architecture design
    Rationale: Keeps client and QA visibility explicit without replacing existing socket flows.
 
 ## Actions Taken
-1. Prepared architect checkout on  and reviewed the current room/gameplay implementation. → Confirmed current forced post-game teardown is the main behavior to change.
-2. Wrote . → Captured state transitions, reset semantics, leave behavior, and implementation order.
-3. Wrote . → Defined rematch socket events, payload additions, semantics, and test assertions.
+1. Prepared architect checkout on `feature/issue-13` and reviewed the current room/gameplay implementation. → Confirmed current forced post-game teardown is the main behavior to change.
+2. Wrote `docs/impl/replay-rematch-flow/design.md`. → Captured state transitions, reset semantics, leave behavior, and implementation order.
+3. Wrote `docs/impl/replay-rematch-flow/api-contracts.md`. → Defined rematch socket events, payload additions, semantics, and test assertions.
 
 ## Outputs
-- : architecture design for same-room rematch flow
-- : socket contracts and payload semantics for rematch
+- `docs/impl/replay-rematch-flow/design.md`: architecture design for same-room rematch flow
+- `docs/impl/replay-rematch-flow/api-contracts.md`: socket contracts and payload semantics for rematch
 
 ## Handoff
 - Next agent: fullstack-dev

--- a/docs/impl/replay-rematch-flow/api-contracts.md
+++ b/docs/impl/replay-rematch-flow/api-contracts.md
@@ -1,0 +1,385 @@
+# API Contracts: Replay / Rematch Flow
+
+## Summary
+These contracts extend the existing Socket.IO room/gameplay protocol to support same-room replay after `game-over`.
+
+Goals:
+- dual acceptance by the same two connected players
+- waiting state when only one accepts
+- same room code across rounds
+- full authoritative reset on rematch start
+- open-room behavior after a post-game leave
+
+The implementation should extend the current shared contract file rather than create a parallel transport model.
+
+## Contract strategy
+Reuse existing events where possible:
+- `lobby:state`
+- `game:state`
+- `game:countdown`
+- `game:start`
+- `game:ended`
+- `player:left`
+- `room:error`
+
+Add one explicit client intent event and one explicit server state event:
+- `game:rematch-request`
+- `game:rematch-state`
+
+Why add an explicit state event even though `lobby:state` / `game:state` also exist?
+- it keeps rematch UI updates obvious and easy to subscribe to
+- it avoids overloading the semantics of lobby payloads
+- it gives dev/QA a narrow surface for post-game verification
+
+For MVP, the server may also embed the same `rematch` object inside `lobby:state` and `game:state` for convenience. If duplicated, all copies must be identical for the same room version.
+
+## Types
+
+```ts
+export type RematchStatus = 'unavailable' | 'idle' | 'waiting' | 'accepted';
+
+export interface RematchView {
+  available: boolean;
+  status: RematchStatus;
+  requestedBySlot: {
+    0: boolean;
+    1: boolean;
+  };
+  requestedByYou: boolean;
+  waitingForOtherPlayer: boolean;
+  bothAccepted: boolean;
+  eligiblePlayerCount: 0 | 1 | 2;
+}
+```
+
+### Shared payload addition
+Recommended extension to room-facing payloads:
+
+```ts
+interface LobbyStatePayload {
+  roomCode: string;
+  phase: RoomPhase;
+  // existing fields...
+  rematch?: RematchView;
+}
+
+interface PublicGameStatePayload {
+  roomCode: string;
+  phase: 'starting' | 'in-progress' | 'game-over';
+  // existing fields...
+  rematch?: RematchView;
+}
+```
+
+Rules:
+- `rematch` may be omitted outside post-game / waiting contexts if the implementation prefers
+- recommended: always include it for consistency once the feature ships
+- during `starting` and `in-progress`, `rematch.available` should be `false`
+
+## New client -> server event
+
+### `game:rematch-request`
+Signals that the calling player wants another round in the same room.
+
+```ts
+export interface GameRematchRequestPayload {}
+```
+
+Validation:
+- socket must belong to a room
+- room phase must be `game-over`
+- caller must still occupy one of the room's current player slots
+- room must still have two occupied/connected players for the request to remain actionable
+
+Behavior:
+- mark caller's acceptance as `true`
+- broadcast updated rematch state
+- if both players have accepted, start rematch immediately via normal countdown path
+
+Idempotency:
+- repeating the same request from the same slot should be a no-op if already accepted
+- server must not create duplicate countdowns or duplicate starts
+
+Error path:
+- invalid phase or caller state should emit `room:error`
+- recommended reason for MVP: existing `ACTION_NOT_ALLOWED`
+
+## New server -> client event
+
+### `game:rematch-state`
+Authoritative post-game rematch snapshot for the room.
+
+```ts
+export interface GameRematchStatePayload {
+  roomCode: string;
+  phase: 'game-over' | 'waiting-for-players' | 'lobby' | 'starting';
+  rematch: RematchView;
+  version: number;
+  message?: string;
+}
+```
+
+Emit when:
+- round first enters `game-over`
+- one player requests rematch
+- both players have requested rematch
+- a player leaves/disconnects after game over
+- room returns to waiting/open state after stale rematch state is cleared
+
+Client expectations:
+- render rematch CTA only when `rematch.available` is true
+- show waiting copy when `waitingForOtherPlayer` is true
+- clear post-game rematch UI when state becomes `unavailable`
+
+## Existing event changes
+
+### `game:ended`
+Current event already communicates round completion. Extend its semantics so clients know the room may remain open.
+
+Recommended addition:
+
+```ts
+interface GameEndedPayload {
+  roomCode: string;
+  phase: 'game-over';
+  result: { /* existing fields */ };
+  finalState: PublicGameStatePayload;
+  teardownAt: number | null;
+  version: number;
+}
+```
+
+Rules:
+- for standard rematch-capable round end, `teardownAt` should be `null`
+- if implementation still has a teardown path for exceptional cases, it may provide a timestamp
+- `finalState.rematch` should show initial rematch availability with both flags false when both players remain connected
+
+### `lobby:state`
+Recommended addition:
+
+```ts
+interface LobbyStatePayload {
+  // existing fields...
+  rematch?: RematchView;
+}
+```
+
+Semantics:
+- in ordinary pre-game lobby flow, `rematch.available = false`
+- after a post-game leave returns the room to `waiting-for-players`, `rematch.available = false` and both flags false
+- this helps the remaining player clear stale result/rematch UI and return to normal lobby waiting UI
+
+### `game:state`
+Recommended addition:
+
+```ts
+interface PublicGameStatePayload {
+  // existing fields...
+  rematch?: RematchView;
+}
+```
+
+Semantics by phase:
+- `starting` / `in-progress`: rematch unavailable
+- `game-over`: rematch reflects acceptance status and availability
+
+### `game:start`
+No new transport event is required, but semantics change slightly for rematch.
+
+Current payload is acceptable if it still represents the start of a fresh round in the same room.
+
+Recommended note:
+- `roomCode` remains unchanged from previous round
+- `startedAt` refers to the new round only
+- `version` must advance from post-game state
+
+### `game:countdown`
+No new payload required.
+
+Semantics:
+- countdown should fire for a rematch exactly like an initial round start
+- clients should not care whether countdown source is initial ready flow or rematch flow
+
+### `player:left`
+Current payload is still acceptable:
+
+```ts
+interface PlayerLeftPayload {
+  roomCode: string;
+  slotIndex: 0 | 1;
+  reason: 'left' | 'disconnected';
+}
+```
+
+Post-game semantics:
+- if emitted while room was in `game-over`, the remaining player must also receive updated room/rematch state showing that rematch is no longer pending and the room is open again
+
+### `room:closed`
+Normal successful round end should no longer imply automatic `room:closed`.
+
+New rule:
+- do not emit `room:closed` merely because a round completed
+- emit it only when the room is actually being destroyed (for example, both players gone, or other future explicit close conditions)
+
+This is the main contract change downstream consumers must honor.
+
+## Recommended event constants
+
+```ts
+export const EVENTS = {
+  // existing events...
+  gameRematchRequest: 'game:rematch-request',
+  gameRematchState: 'game:rematch-state',
+} as const;
+```
+
+## Canonical rematch state examples
+
+### 1. Round just ended, both players still present
+```json
+{
+  "roomCode": "ABCD",
+  "phase": "game-over",
+  "rematch": {
+    "available": true,
+    "status": "idle",
+    "requestedBySlot": { "0": false, "1": false },
+    "requestedByYou": false,
+    "waitingForOtherPlayer": false,
+    "bothAccepted": false,
+    "eligiblePlayerCount": 2
+  },
+  "version": 41,
+  "message": "Round complete. Choose rematch to play again."
+}
+```
+
+### 2. Player 1 accepted, waiting on player 2
+```json
+{
+  "roomCode": "ABCD",
+  "phase": "game-over",
+  "rematch": {
+    "available": true,
+    "status": "waiting",
+    "requestedBySlot": { "0": true, "1": false },
+    "requestedByYou": true,
+    "waitingForOtherPlayer": true,
+    "bothAccepted": false,
+    "eligiblePlayerCount": 2
+  },
+  "version": 42,
+  "message": "Waiting for the other player to accept rematch."
+}
+```
+
+### 3. Both players accepted, round restarting
+```json
+{
+  "roomCode": "ABCD",
+  "phase": "starting",
+  "rematch": {
+    "available": false,
+    "status": "accepted",
+    "requestedBySlot": { "0": true, "1": true },
+    "requestedByYou": true,
+    "waitingForOtherPlayer": false,
+    "bothAccepted": true,
+    "eligiblePlayerCount": 2
+  },
+  "version": 43,
+  "message": "Rematch accepted. Starting now."
+}
+```
+
+Implementation note:
+- it is acceptable to skip broadcasting this intermediate accepted snapshot if the server transitions immediately into `game:countdown` / `game:start`
+- if skipped, the next visible payloads must still be consistent
+
+### 4. Opponent leaves after game over
+```json
+{
+  "roomCode": "ABCD",
+  "phase": "waiting-for-players",
+  "rematch": {
+    "available": false,
+    "status": "unavailable",
+    "requestedBySlot": { "0": false, "1": false },
+    "requestedByYou": false,
+    "waitingForOtherPlayer": false,
+    "bothAccepted": false,
+    "eligiblePlayerCount": 1
+  },
+  "version": 44,
+  "message": "Other player left. Room is open for another player."
+}
+```
+
+## Sequence diagrams
+
+### A. One player accepts first
+```text
+server -> both: game:ended
+server -> both: game:rematch-state { status: idle }
+
+player-0 -> server: game:rematch-request
+server -> both: game:rematch-state { status: waiting, requestedBySlot[0]=true }
+```
+
+### B. Both players accept
+```text
+server -> both: game:ended
+server -> both: game:rematch-state { status: idle }
+
+player-0 -> server: game:rematch-request
+server -> both: game:rematch-state { status: waiting }
+
+player-1 -> server: game:rematch-request
+server -> both: game:countdown { secondsRemaining: 3 }
+server -> both: game:countdown { secondsRemaining: 2 }
+server -> both: game:countdown { secondsRemaining: 1 }
+server -> both: game:countdown { secondsRemaining: 0 }
+server -> both: game:start
+server -> both: game:state
+```
+
+### C. Waiting player loses opponent
+```text
+server -> both: game:ended
+player-0 -> server: game:rematch-request
+server -> both: game:rematch-state { status: waiting }
+
+player-1 disconnects
+server -> player-0: player:left
+server -> player-0: lobby:state { phase: waiting-for-players, rematch.available=false }
+server -> player-0: game:rematch-state { status: unavailable }
+```
+
+## Validation matrix
+
+### `game:rematch-request`
+Allowed:
+- caller is in room
+- phase = `game-over`
+- room still has two occupied connected players
+
+Rejected with `ACTION_NOT_ALLOWED`:
+- caller not in a room
+- phase is `waiting-for-players`, `lobby`, `starting`, or `in-progress`
+- caller no longer occupies a room slot
+- room composition changed such that rematch is unavailable
+
+## Backward-compatibility notes
+1. Existing clients may currently assume `room:closed` after every `game:ended`; that assumption must be removed.
+2. Existing `game-over` UI likely needs to stop resetting back to the create/join flow automatically.
+3. Existing shared types should be expanded in place under `src/shared/contracts.ts`.
+4. Tests should assert that a normal completed round no longer emits `room:closed` immediately.
+
+## Test assertions for the next agent
+Add socket/service tests to verify:
+1. `game:ended` on normal completion is followed by rematch-available state, not forced `room:closed`
+2. first `game:rematch-request` updates only one slot's acceptance
+3. second request starts a fresh countdown in the same `roomCode`
+4. post-rematch `game:start` has reset score/tick/board state
+5. post-game disconnect emits `player:left` plus cleared rematch state
+6. replacement join after post-game leave works through existing `room:join` + lobby flow

--- a/docs/impl/replay-rematch-flow/deploy-log.md
+++ b/docs/impl/replay-rematch-flow/deploy-log.md
@@ -65,3 +65,35 @@ Verification result: **PASS**
 | URL | `http://20.106.185.110:8081/` |
 | Timestamp | `2026-03-12T00:44:35Z` |
 | Status | `SUCCESS` |
+
+## Redeploy refresh — 2026-03-12
+- Trigger: stakeholder review refresh after rematch CTA visibility fix
+- Source commit: `dc5e3b6ed2eeb8f86afbd9d298627243882bc28f` (`dc5e3b6`)
+- Redeployed at (UTC): `2026-03-12T01:00:26Z`
+- Result: `SUCCESS`
+
+### Refresh verification
+- `~/deployments/dev` reset to `origin/feature/issue-13` at `dc5e3b6ed2eeb8f86afbd9d298627243882bc28f`
+- `npm ci && npm run build` completed successfully
+- `pm2 restart app-dev --update-env` completed successfully
+- `curl http://127.0.0.1:3001/` returned `200`
+- `curl http://20.106.185.110:8081/` returned `200`
+- Served `/app.js` SHA-256 matched the deployed file SHA-256: `e7f4149980ef5fece49e86cb86448c70855c634b79d76f7365da02a4dd618815`
+- Served asset contains the rematch CTA visibility fix strings:
+  - `Accept rematch now`
+  - `Your opponent wants a rematch. Accept to restart in the same room.`
+  - highlighted rematch card state
+
+### Latest deployment record
+
+| Field | Value |
+|-------|-------|
+| Commit | `dc5e3b6ed2eeb8f86afbd9d298627243882bc28f` |
+| Short | `dc5e3b6` |
+| Branch | `feature/issue-13` |
+| Environment | `dev` |
+| PM2 Process | `app-dev` |
+| URL | `http://20.106.185.110:8081/` |
+| Timestamp | `2026-03-12T01:00:26Z` |
+| Status | `SUCCESS` |
+

--- a/docs/impl/replay-rematch-flow/deploy-log.md
+++ b/docs/impl/replay-rematch-flow/deploy-log.md
@@ -1,0 +1,67 @@
+# Dev deployment log — Replay / Rematch Flow
+
+## Deployment target
+- Parent issue: `#13`
+- PR: `#16`
+- Branch: `feature/issue-13`
+- Feature slug: `replay-rematch-flow`
+- Environment: `dev`
+- Dev URL: `http://20.106.185.110:8081/`
+- Deployed commit: `ec7474c03b459df85bc5549a69293244b04838ab` (`ec7474c`)
+- Deployed at (UTC): `2026-03-12T00:44:35Z`
+- Runtime: `pm2` process `app-dev` behind nginx on port `8081`, forwarding to local app on port `3001`
+
+## Deployment actions
+```bash
+cd /home/rootagent/deployments/dev
+git fetch origin feature/issue-13
+git checkout feature/issue-13 || git checkout -b feature/issue-13 origin/feature/issue-13
+git reset --hard origin/feature/issue-13
+npm ci
+npm run build
+pm2 startOrRestart /home/rootagent/deployments/ecosystem.config.js --only app-dev
+pm2 save
+```
+
+## Health checks
+- `pm2 list` showed `app-dev` online after restart.
+- `curl -I http://20.106.185.110:8081/` returned `HTTP/1.1 200 OK`.
+- `curl http://20.106.185.110:8081/build-info.json` returned build marker `v0.1.0+ec7474c`.
+- Deployed `app.js` at the dev URL includes the rematch UI / transport wiring for:
+  - `game:rematch-request`
+  - `game:rematch-state`
+  - waiting-state messaging
+  - same-room replay UI controls
+
+## Live rematch verification
+A two-client live Socket.IO verification was run against the deployed dev URL.
+
+Verified live:
+1. Room creation and join both succeeded.
+2. Both players could ready up and start a round.
+3. After `game-over`, rematch became available for both clients.
+4. One-player rematch acceptance produced authoritative waiting state (`status=waiting`) visible to both clients.
+5. Second-player acceptance restarted the game in the **same room code** with a fresh countdown.
+6. The rematch round reset to clean state:
+   - scores reset to `0`
+   - `tickIntervalMs` reset to `200`
+   - room code remained unchanged
+7. After a later post-game leave, the remaining player received:
+   - `player:left`
+   - `lobby:state` with phase `waiting-for-players`
+   - cleared rematch state with both acceptance flags reset and `available=false`
+
+Verification result: **PASS**
+
+## Deployment record
+
+| Field | Value |
+|-------|-------|
+| Commit | `ec7474c03b459df85bc5549a69293244b04838ab` |
+| Short | `ec7474c` |
+| Branch | `feature/issue-13` |
+| Environment | `dev` |
+| PM2 Process | `app-dev` |
+| URL | `http://20.106.185.110:8081/` |
+| Timestamp | `2026-03-12T00:44:35Z` |
+| Status | `SUCCESS` |

--- a/docs/impl/replay-rematch-flow/design.md
+++ b/docs/impl/replay-rematch-flow/design.md
@@ -1,0 +1,387 @@
+# Design: Replay / Rematch Flow
+
+## Summary
+This design extends the existing in-memory 2-player `RoomService` so a completed round can be replayed in the **same room** with the **same room code**.
+
+The core rule is simple:
+- after `game-over`, both currently connected players may independently accept a rematch
+- the next round starts only when **both** players have accepted
+- the room stays open if one player leaves after game over
+- starting a rematch creates a **brand-new match state** and runs the normal countdown again
+- the system does **not** return through the original pre-game ready flow
+
+This feature should reuse the current server-authoritative room lifecycle and gameplay engine rather than introducing a second replay-specific subsystem.
+
+## Existing baseline
+Today the repo already has:
+- a server-authoritative `RoomService`
+- in-memory room records keyed by `roomCode`
+- room phases: `waiting-for-players` / `lobby` / `starting` / `in-progress` / `game-over`
+- gameplay countdown + tick runtime
+- terminal `game-over` handling followed by forced `room:closed` teardown after ~3 seconds
+
+That forced teardown is the main behavior that must change for this feature.
+
+## Design goals
+1. Keep rematch state entirely server-authoritative.
+2. Preserve the same room code and player slot identities across rounds when both players stay.
+3. Require explicit dual acceptance before replay.
+4. Fully reset round state with no leakage from the previous match.
+5. Preserve current waiting-room behavior when one player leaves after game over.
+6. Minimize implementation churn by evolving `RoomService`, not replacing it.
+
+## High-level approach
+
+### 1. Keep completed rooms alive after `game-over`
+Replace the current "always teardown after result window" behavior with a reusable post-game state:
+- room remains in memory after `game-over`
+- final result remains visible
+- room can accept post-game actions
+- room is only destroyed when both players are gone, or when the remaining lifecycle rules say it should be removed
+
+### 2. Add rematch acceptance state to the room record
+The room needs explicit, per-slot rematch tracking that is separate from pre-game ready state.
+
+Recommended addition:
+
+```ts
+interface RematchState {
+  requestedBySlot: {
+    0: boolean;
+    1: boolean;
+  };
+  eligiblePlayerCount: 0 | 1 | 2;
+  status: 'unavailable' | 'idle' | 'waiting' | 'accepted';
+}
+```
+
+Recommended `RoomRecord` extension:
+
+```ts
+interface RoomRecord {
+  roomCode: string;
+  phase: RoomPhase;
+  version: number;
+  players: [PlayerSlot, PlayerSlot];
+  match: MatchState | null;
+  countdown: CountdownState | null;
+  teardownAt: number | null;
+  rematch: RematchState;
+}
+```
+
+Implementation note:
+- `ready` continues to mean **pre-game lobby readiness only**
+- `rematch.requestedBySlot` is a distinct post-game concept
+- do not overload `ready` to mean both things
+
+## State model
+
+### Room phases
+Keep the existing room phases and semantics:
+- `waiting-for-players`
+- `lobby`
+- `starting`
+- `in-progress`
+- `game-over`
+
+Do **not** add a separate `rematch-pending` room phase for MVP.
+
+Why:
+- `game-over` already represents the correct broad state
+- rematch is a sub-state of `game-over`
+- keeping one terminal room phase reduces branching in client and server code
+
+Instead, represent rematch via a dedicated `rematch` object published in room/game payloads.
+
+### Rematch sub-states within `game-over`
+Inside `game-over`:
+- `idle`: no connected player has accepted rematch yet
+- `waiting`: exactly one connected player has accepted
+- `accepted`: both connected players have accepted and restart is being committed
+- `unavailable`: fewer than 2 connected/occupied players are currently eligible
+
+Suggested derivation:
+- both players present, none accepted -> `idle`
+- both players present, one accepted -> `waiting`
+- both players present, two accepted -> `accepted`
+- otherwise -> `unavailable`
+
+## Authoritative data rules
+
+### Eligibility
+Only the two players currently occupying the room's slots for that finished round are eligible to accept rematch.
+
+A rematch action is valid only when:
+- room exists
+- room phase is `game-over`
+- caller still occupies a live room slot
+- both player slots are still occupied and connected when attempting to actually start the rematch
+
+### Acceptance persistence
+Acceptance should persist while the room composition remains unchanged.
+
+Examples:
+- player 1 accepts, player 2 has not yet accepted -> keep player 1's acceptance true
+- player 2 later accepts -> start rematch
+- player 1 accepts, then player 2 disconnects -> clear stale acceptance because room composition changed
+
+### Reset-on-membership-change rule
+Any leave/disconnect after `game-over` invalidates the pending rematch agreement.
+
+On post-game leave/disconnect:
+- clear the departed slot from the room as usual
+- set both `requestedBySlot` values to `false`
+- set `match` to `null` after preserving any client-visible final result long enough to be consumed, or preserve final result separately if needed for UI
+- transition room back to `waiting-for-players`
+- keep room code alive for the remaining player
+
+This directly satisfies the requirement to clear stale rematch acceptance when room state changes.
+
+## Lifecycle transitions
+
+### A. Round ends normally
+Current flow:
+- gameplay loop determines result
+- room enters `game-over`
+- `game:ended` is emitted
+- room is later torn down automatically
+
+New flow:
+1. gameplay loop determines result
+2. room enters `game-over`
+3. server clears any old rematch flags to `{0:false,1:false}`
+4. server emits updated room/game payloads showing rematch is available
+5. server does **not** schedule forced room teardown for `round-complete`
+
+Result: both players stay in the same room and can request rematch.
+
+### B. One player requests rematch first
+1. client emits rematch request
+2. server verifies caller belongs to the room and phase is `game-over`
+3. server marks that player's rematch acceptance `true`
+4. server recalculates rematch status = `waiting`
+5. server broadcasts updated authoritative state to both players
+
+Client outcome:
+- requester sees "Waiting for other player"
+- other player sees that opponent wants a rematch
+- no countdown starts yet
+
+### C. Second player accepts rematch
+1. second client emits rematch request
+2. server marks acceptance for that slot
+3. server atomically verifies both slots are still occupied and connected
+4. server creates a fresh `MatchState`
+5. server clears post-game result/teardown metadata
+6. server clears rematch acceptance back to false/false
+7. room phase becomes `starting`
+8. normal 3-second countdown starts
+9. existing `game:countdown`, `game:start`, and `game:state` flow resumes
+
+Important: this bypasses the original lobby ready-up path.
+
+### D. One player leaves after game over
+1. player disconnects or explicitly leaves while room phase is `game-over`
+2. room removes that player from the slot
+3. rematch acceptance is reset for both slots
+4. remaining player receives `player:left` plus updated room/rematch state
+5. room phase returns to `waiting-for-players`
+6. room stays joinable via the same code
+
+This aligns post-game leave handling with the earlier lobby rule: the room survives when one player leaves.
+
+### E. Replacement player joins after post-game leave
+If one player left after game over and the room returned to `waiting-for-players`, a replacement second player may join using the same room code.
+
+Recommended behavior after replacement joins:
+- replacement player joins into ordinary lobby flow
+- both players must use the normal lobby ready flow for the next round
+- they do **not** inherit rematch state from the previous opponent pairing
+
+Rationale:
+- rematch is for the same two players from the finished round
+- a replacement player represents a new session pairing, not a continuation of the prior rematch offer
+
+## Reset semantics for a new rematch round
+When a rematch starts, treat it exactly like a fresh call to `createInitialMatchState(roomCode)`.
+
+The next agent should ensure these are reset from scratch:
+- both player scores = `0`
+- both snakes reset to initial body positions
+- snake directions reset to default starting directions
+- queued input buffers cleared
+- alive/dead state reset to alive
+- food respawned from a fresh valid initial spawn
+- foods eaten counter reset
+- tick number reset to `0`
+- speed / `tickIntervalMs` reset to default starting speed
+- countdown restarts from `3`
+- terminal result and death reason data from the prior round cleared
+- any previous teardown timer canceled
+
+Implementation rule:
+- never mutate the previous `MatchState` back toward "fresh"
+- construct a new `MatchState` object and replace the old one atomically
+
+That minimizes state leakage bugs.
+
+## Server design changes
+
+### 1. `finishMatch(...)`
+Update `finishMatch(...)` so it supports two different outcomes:
+
+#### Round completed normally
+For `round-complete`:
+- enter `game-over`
+- publish final game/result payloads
+- initialize/reset rematch state
+- **do not** schedule `room:closed`
+
+#### Player disconnected during active play
+For `player-disconnected` during `starting` or `in-progress`:
+- preserve the current behavior that ends the round immediately
+- after the disconnect mutation completes, room should remain open if one player remains
+- do not force-close the room solely because gameplay ended by disconnect
+
+Recommended simplification:
+- separate `finishMatch(...)` from `scheduleRoomClosure(...)`
+- only call closure when room truly needs destruction, not as an automatic post-game rule
+
+### 2. `leaveCurrentRoom(...)`
+Extend leave handling with explicit post-game behavior.
+
+Current code already:
+- clears departing slot
+- deletes room when empty
+- returns surviving player to `waiting-for-players` in lobby phases
+
+New requirement for `game-over`:
+- treat post-game leave like lobby leave, not like fatal room teardown
+- clear rematch state
+- clear stale ready state on remaining player if applicable
+- set `match = null` once post-game state is no longer needed for the next flow
+- set `phase = waiting-for-players`
+- broadcast `player:left` and refreshed `lobby:state`
+
+### 3. Add explicit rematch action handler
+Introduce a dedicated `requestRematch(socketId)` room-service method.
+
+Responsibilities:
+- validate room and phase
+- locate caller slot
+- reject if caller already accepted and action is idempotent/no-op
+- set caller's rematch acceptance
+- broadcast rematch state update
+- if both accepted, transition directly into `starting`
+
+Optional extension for future flexibility:
+- support `setRematch(socketId, accepted: boolean)` so a player can cancel before the second acceptance
+
+For MVP, the spec only requires acceptance/request, not cancel.
+
+### 4. Start path reuse
+Refactor `afterLobbyMutation(room)` into a more generic start primitive so both flows can reuse it:
+- lobby ready flow
+- rematch accepted flow
+
+Suggested split:
+
+```ts
+private startRound(room: RoomRecord, source: 'initial-start' | 'rematch'): ClientEvent[]
+private canStartInitialRound(room: RoomRecord): boolean
+private canStartRematch(room: RoomRecord): boolean
+```
+
+`startRound(...)` should:
+- set phase to `starting`
+- create fresh `MatchState`
+- create fresh countdown state
+- clear terminal result metadata
+- emit countdown/game-state events
+- schedule countdown runtime
+
+## Client design implications
+
+### Result screen behavior
+After `game:ended`, the result screen should remain visible, but it must now show rematch controls instead of waiting for forced room closure.
+
+UI states:
+- neutral: "Play again?"
+- local accepted: "Waiting for other player..."
+- remote accepted only: "Other player wants a rematch"
+- both accepted / starting: countdown resumes immediately
+
+### Room continuity
+Client should no longer assume `game-over` is always followed by `room:closed`.
+
+Instead:
+- stay bound to the same room code after result
+- keep rendering authoritative updates
+- transition back to lobby if a player leaves and server reports `waiting-for-players`
+
+### Open room after leave
+When server reports that one player left after game over:
+- keep the remaining player in-room
+- show same room code
+- show waiting/open messaging consistent with the lobby
+- clear any rematch CTA state derived from prior opponent acceptance
+
+## Concurrency and correctness notes
+
+### Nearly simultaneous rematch clicks
+Because Node processes events serially within the same process, two rematch requests can be handled safely if the service:
+- mutates room state synchronously
+- re-checks both slot occupancies before starting
+- transitions to `starting` exactly once
+
+Guardrail:
+- if room phase is no longer `game-over` by the time the second request is processed, reject or no-op it
+
+### Duplicate acceptance / button spam
+If a player clicks rematch more than once:
+- repeated requests should be idempotent
+- server should not increment version excessively unless state changed
+- do not start multiple countdowns
+
+### Disconnect during rematch waiting
+If one player accepted and the other disconnects:
+- clear both acceptance flags
+- revert to `waiting-for-players`
+- keep room open for replacement
+
+### Disconnect during rematch countdown
+If both accepted and countdown started, existing `starting` disconnect rules should apply:
+- current round attempt terminates
+- surviving player remains in reusable room
+- room returns to open/waiting state rather than forced destruction
+
+## Suggested implementation order
+1. Extend shared contracts with rematch event and payload types.
+2. Extend `RoomRecord` with rematch state.
+3. Remove unconditional room teardown after normal `game-over`.
+4. Implement post-game rematch request handler in `RoomService`.
+5. Refactor round-start logic into a reusable `startRound(...)` helper.
+6. Update leave/disconnect handling so `game-over` returns to an open room when one player remains.
+7. Update client result-screen state and rematch CTA rendering.
+8. Add tests for rematch acceptance, reset semantics, post-game leave, and replacement join behavior.
+
+## Required tests
+The next agent should add service/integration coverage for at least:
+1. normal round end keeps room alive and exposes rematch state
+2. one rematch acceptance produces waiting state only
+3. second rematch acceptance starts fresh countdown in same room
+4. rematch resets score, snakes, food, tick number, and speed
+5. rematch does not require pre-game ready flow
+6. one player leaves after game over and room remains open
+7. rematch acceptance is cleared when a player leaves after game over
+8. replacement player can join same room after post-game leave
+9. duplicate rematch requests do not start duplicate countdowns
+10. disconnect during rematch countdown resolves cleanly without corrupting room state
+
+## Handoff guidance for fullstack dev
+- Treat this as an evolution of `RoomService`, not a rewrite.
+- Reuse the existing countdown + gameplay runtime; do not invent a separate rematch engine.
+- Make `game-over` a reusable room state instead of a short-lived teardown-only state.
+- Keep initial lobby ready-up and post-game rematch acceptance as distinct concepts in data and UI.
+- Prefer introducing one authoritative rematch snapshot/event shape and derive UI strictly from server state.

--- a/docs/impl/replay-rematch-flow/dev-notes.md
+++ b/docs/impl/replay-rematch-flow/dev-notes.md
@@ -9,6 +9,8 @@
 - Allowed replacement players to rejoin the same room after a post-game leave and return through the normal lobby ready flow.
 - Added browser UI for rematch acceptance and waiting/accepted messaging on the game-over screen.
 
+- Follow-up review fixes: duplicate `game:rematch-request` accepts are now a no-op, and duplicated rematch payloads stay viewer-consistent across `lobby:state`, `game:state`, and `game:rematch-state`.
+
 ## Notes / Deviations
 - `game:rematch-state` is emitted alongside updated `lobby:state` and `game:state` so the client can render a focused rematch panel without inferring post-game state from multiple payload shapes.
 - After a disconnect during active play, the service still ends the match immediately, but it no longer force-closes the room afterward; the remaining player can keep the room code and wait for a replacement.

--- a/docs/impl/replay-rematch-flow/dev-notes.md
+++ b/docs/impl/replay-rematch-flow/dev-notes.md
@@ -14,3 +14,11 @@
 ## Notes / Deviations
 - `game:rematch-state` is emitted alongside updated `lobby:state` and `game:state` so the client can render a focused rematch panel without inferring post-game state from multiple payload shapes.
 - After a disconnect during active play, the service still ends the match immediately, but it no longer force-closes the room afterward; the remaining player can keep the room code and wait for a replacement.
+
+
+## Follow-up: stakeholder visibility fix
+- Investigated the stakeholder report against both the feature branch and the current dev deployment (`v0.1.0+ec7474c`). The rematch feature was already shipped and wired correctly; the problem was discoverability.
+- Root cause: the only rematch CTA lived in the narrow left sidebar beside the board, so after game over it was easy to miss while attention stayed centered on the result board/message.
+- Added a prominent post-game rematch banner directly above the board with the same authoritative action wiring as the sidebar button.
+- Updated button/status copy so the call to action is stronger (`Accept rematch now`, `Waiting for other player`, `Rematch starting…`) while keeping the underlying room/rematch state machine unchanged.
+- Kept the original sidebar rematch card, but now visually highlight it during actionable post-game states so both desktop and mobile layouts make the replay affordance obvious.

--- a/docs/impl/replay-rematch-flow/dev-notes.md
+++ b/docs/impl/replay-rematch-flow/dev-notes.md
@@ -1,0 +1,14 @@
+# Development Notes: Replay / Rematch Flow
+
+## Implemented
+- Added server-authoritative rematch state and `game:rematch-request` / `game:rematch-state` transport support.
+- Kept `game-over` as the post-round phase and modeled rematch as a sub-state on the room.
+- Removed automatic room closure after normal `game:ended`; rooms now stay open for same-room replay.
+- Reused the existing countdown/start pipeline for rematches by creating a fresh `MatchState` before restarting.
+- Cleared stale rematch acceptance and returned rooms to `waiting-for-players` when a post-game leave/disconnect happens.
+- Allowed replacement players to rejoin the same room after a post-game leave and return through the normal lobby ready flow.
+- Added browser UI for rematch acceptance and waiting/accepted messaging on the game-over screen.
+
+## Notes / Deviations
+- `game:rematch-state` is emitted alongside updated `lobby:state` and `game:state` so the client can render a focused rematch panel without inferring post-game state from multiple payload shapes.
+- After a disconnect during active play, the service still ends the match immediately, but it no longer force-closes the room afterward; the remaining player can keep the room code and wait for a replacement.

--- a/docs/impl/replay-rematch-flow/qa-report.md
+++ b/docs/impl/replay-rematch-flow/qa-report.md
@@ -1,0 +1,68 @@
+# QA Report: Replay / Rematch Flow
+
+## Summary
+- Parent issue: #13
+- PR: #16
+- Branch: `feature/issue-13`
+- Feature slug: `replay-rematch-flow`
+- Environment: dev (`http://20.106.185.110:8081/`)
+- QA verdict: **PASS**
+- QA date (UTC): 2026-03-12
+
+## Test approach
+1. Read the approved spec plus implementation artifacts in `docs/impl/replay-rematch-flow/`.
+2. Ran targeted source-level regression coverage: `npm test -- src/server/__tests__/roomService.test.ts`.
+3. Ran live two-client Socket.IO checks against the deployed dev URL to verify same-room rematch behavior and post-game leave behavior.
+4. Inspected deployed `app.js` for the rematch CTA copy introduced by the follow-up visibility fix.
+
+## Evidence summary
+- Source-level regression suite passed: `9/9` tests in `src/server/__tests__/roomService.test.ts`.
+- Live same-room rematch run used room code `IORJ`.
+- Live post-game leave run used room code `NFYA`.
+- Deployed client bundle contains the post-game CTA strings:
+  - `Accept rematch now`
+  - `Waiting for other player`
+  - `Your opponent wants a rematch. Accept to restart in the same room.`
+  - `Rematch starting…`
+
+## Acceptance criteria matrix
+
+| # | Acceptance criterion | Result | Evidence |
+|---|---|---|---|
+| 1 | After game over, both players can see and use a rematch option. | PASS | Live run `IORJ`: both clients received `game:ended` with `finalState.rematch.available=true`, `status=idle`, and `teardownAt=null`. Deployed `app.js` includes the visible CTA strings `Accept rematch now` and `Your opponent wants a rematch. Accept to restart in the same room.` |
+| 2 | The round restarts only after both players accept rematch. | PASS | In `IORJ`, after player A requested rematch, both clients stayed in `phase=game-over` with `rematch.status=waiting`. Only after player B requested rematch did both clients transition to `phase=starting` for the rematch. |
+| 3 | If only one player accepts, the UI clearly shows that it is waiting for the other player. | PASS | In `IORJ`, player A saw `requestedByYou=true`, `waitingForOtherPlayer=true`, `status=waiting`; player B saw the same authoritative room state with `requestedByYou=false`. The deployed client bundle contains `Waiting for other player` and opponent-prompt copy. |
+| 4 | The rematch happens in the same room with the same room code. | PASS | In `IORJ`, the initial round, post-game state, and rematch countdown all kept `roomCode="IORJ"` for both clients. |
+| 5 | Starting a rematch resets scores to 0. | PASS | In `IORJ`, rematch `game:state` at `phase=starting` showed `snakes[0].score=0` and `snakes[1].score=0`. |
+| 6 | Starting a rematch resets snakes, food, speed, and other round state. | PASS | In `IORJ`, rematch `game:state` showed `tickNumber=0`, `foodsEaten=0`, `tickIntervalMs=200`, fresh food at `{x:24,y:27}`, and reset snake bodies to the documented starting positions (`[{7,15},{6,15},{5,15}]` and `[{22,15},{23,15},{24,15}]`). |
+| 7 | Starting a rematch shows a fresh countdown before movement begins. | PASS | In `IORJ`, countdown history showed the initial round countdown and then a fresh rematch countdown; the rematch transition emitted `game:countdown` again with `secondsRemaining=3` and `phase=starting`. |
+| 8 | Rematch does not require going back through the separate ready-state flow. | PASS | In `IORJ`, once both rematch requests were in, the room moved directly from `game-over` to `starting`. No additional `player:ready:set` actions were needed. |
+| 9 | If one player leaves after game over, the room remains open. | PASS | In `NFYA`, after player A requested rematch and player B disconnected during post-game waiting, player A received `player:left`, `lobby:state.phase=waiting-for-players`, the same `roomCode="NFYA"`, and `roomClosedEvents=0`. |
+| 10 | No special rematch timeout interrupts the waiting state. | PASS | In `IORJ`, after one rematch acceptance, the room remained in `phase=game-over` with `status=waiting` after an additional 4.5 seconds; no timeout-driven reset or room closure occurred. |
+
+## Additional verification notes
+- `game:ended.teardownAt` was `null` in the live `IORJ` run, matching the intended “do not force-close after normal game over” behavior.
+- The post-game leave scenario in `NFYA` also cleared stale rematch state correctly: `rematch.available=false`, both `requestedBySlot` flags reset to `false`, and `eligiblePlayerCount=1`.
+- The targeted Vitest coverage includes regression cases for:
+  - one-player rematch waiting state
+  - duplicate rematch requests being a no-op
+  - viewer-consistent rematch payloads across event types
+  - rematch reset semantics
+  - post-game leave keeping the room open
+  - replacement join returning to normal lobby flow
+
+## Defects / blockers
+- None found during QA.
+
+## Commands / checks run
+```bash
+cd /home/rootagent/openclaw-startup-factory/openclaw/state/checkouts/qa/current
+npm ci
+npm test -- src/server/__tests__/roomService.test.ts
+curl -fsSL http://20.106.185.110:8081/app.js | rg "Accept rematch now|Waiting for other player|Your opponent wants a rematch|Rematch starting"
+node /tmp/qa13-live/live-rematch-check.mjs
+node /tmp/qa13-live/live-postgame-leave-check.mjs
+```
+
+## Final verdict
+**PASS** — the dev deployment satisfies the approved replay / rematch acceptance criteria for issue #13.

--- a/docs/impl/replay-rematch-flow/review-cycle-1.md
+++ b/docs/impl/replay-rematch-flow/review-cycle-1.md
@@ -1,0 +1,52 @@
+# Review Cycle 1
+
+## Verdict
+CHANGES_REQUESTED
+
+## What I reviewed
+- PR #16 against `docs/impl/replay-rematch-flow/spec.md`
+- `docs/impl/replay-rematch-flow/design.md`
+- `docs/impl/replay-rematch-flow/api-contracts.md`
+- `docs/impl/replay-rematch-flow/dev-notes.md`
+- Server/client implementation and automated coverage
+
+## What looks good
+- Rematch gating stays server-authoritative in `RoomService` and only transitions to a fresh round after both players accept.
+- Rematch reuses the same room code and correctly creates a fresh `MatchState` with a new countdown.
+- Post-game leave/disconnect clears stale rematch acceptance and keeps the room joinable for a replacement player.
+- Coverage was added for the main replay/rematch scenarios, and the current test suite/build pass locally after installing dependencies.
+
+## Required fixes
+
+### 1. Make `game:rematch-request` idempotent once a player has already accepted
+**Why it matters:**
+The API contract explicitly says repeated requests from the same slot should be a no-op. Right now `requestRematch()` always sets the slot to `true`, increments `room.version`, and rebroadcasts state even when that player already accepted. That violates the contract and can create unnecessary state churn/version bumps if a client retries or a user double-clicks.
+
+**Where:**
+- `src/server/roomService.ts` → `requestRematch()`
+
+**What to change:**
+- If `room.rematch.requestedBySlot[player.slotIndex]` is already `true`, return without mutating room state or incrementing the version.
+- Add a regression test proving duplicate requests from the same player do not advance version or emit a second state transition.
+
+### 2. Make duplicated rematch payloads truly identical across `lobby:state`, `game:state`, and `game:rematch-state`
+**Why it matters:**
+The API contract says that if rematch data is duplicated across payloads, all copies must be identical for the same room version. The current implementation serializes viewer-specific rematch data in `lobby:state` / `game:rematch-state`, but `game:state` calls `buildRematchView(room)` without a viewer socket, so `requestedByYou` is always `false` there. That means the same room version can expose different rematch objects depending on which event the client reads.
+
+This mismatch is especially relevant because the browser stores and renders rematch UI from multiple event types.
+
+**Where:**
+- `src/server/roomService.ts`
+  - `serializeLobbyState()` uses `this.buildRematchView(room, viewerSocketId)`
+  - `buildRematchStateEvents()` uses `this.buildRematchView(room, player.socketId)`
+  - `serializeGameState()` uses `this.buildRematchView(room)`
+
+**What to change:**
+- Either make `game:state` viewer-specific too, or remove viewer-specific fields from the duplicated payload shape.
+- At minimum, ensure `requestedByYou` is consistent anywhere the same `rematch` object is exposed for a given viewer/version.
+- Add a test covering a one-player-accepted state and asserting the rematch object seen by the requesting player is consistent across the emitted event types.
+
+## Validation performed
+- `npm install`
+- `npm test`
+- `npm run build`

--- a/docs/impl/replay-rematch-flow/review-cycle-2.md
+++ b/docs/impl/replay-rematch-flow/review-cycle-2.md
@@ -1,0 +1,39 @@
+# Review Cycle 2
+
+## Verdict
+APPROVED
+
+## Focus of this review
+Re-checked the two blocking issues from review cycle 1:
+1. `game:rematch-request` idempotency after a player has already accepted.
+2. Viewer-consistent rematch payloads across `lobby:state`, `game:state`, and `game:rematch-state`.
+3. Regression coverage for both fixes.
+
+## Findings
+
+### 1. Duplicate rematch requests are now idempotent
+`RoomService.requestRematch()` now returns early when the caller's slot has already accepted:
+- no room mutation
+- no version bump
+- no duplicate state broadcasts
+
+That matches the API contract and removes the state churn called out in cycle 1.
+
+### 2. Rematch payloads are now viewer-consistent
+`buildGameStateEvents()` now serializes `game:state` per recipient and passes the viewer socket id through to `serializeGameState()`, which in turn calls `buildRematchView(room, viewerSocketId)`.
+
+That aligns `game:state` with the existing per-viewer handling in `lobby:state` and `game:rematch-state`, so `requestedByYou` and related derived fields are consistent for the same viewer/version.
+
+### 3. Regression coverage is meaningful
+The added tests cover the previously blocking regressions directly:
+- `duplicate rematch requests from the same player are a no-op`
+- `rematch payload stays viewer-consistent across lobby, game, and rematch events`
+
+The viewer-consistency test checks both players' views across all three event types, which is the key failure mode from cycle 1.
+
+## Validation performed
+- `npm install`
+- `npm test -- src/server/__tests__/roomService.test.ts`
+
+## Conclusion
+The two blocking issues from cycle 1 are resolved, and the new tests meaningfully lock in the intended behavior.

--- a/docs/impl/replay-rematch-flow/spec.md
+++ b/docs/impl/replay-rematch-flow/spec.md
@@ -1,0 +1,139 @@
+# Feature Spec: Replay / Rematch Flow
+
+## Status
+Draft for stakeholder approval
+
+## Feature Summary
+As a player, I want to request a rematch with the same opponent in the same room after a round ends so that we can quickly play again without creating a new room from scratch.
+
+## Scope
+In scope for this feature:
+- post-game rematch UI
+- both-player rematch acceptance flow
+- waiting state when only one player accepts rematch
+- replay in the same room with the same room code
+- full round reset for rematch
+- score reset for the new round
+- fresh countdown before the rematch starts
+- room behavior when one player leaves after game over
+
+Out of scope for this feature:
+- matchmaking with a new opponent
+- persistent match history
+- timeout-based rematch expiration
+- ranked scoring or session totals across rounds
+- spectator support
+
+## Stakeholder Decisions Captured
+- Both players must accept the rematch.
+- Rematch stays in the same room with the same room code.
+- Once both players accept, the rematch starts directly without going back to a separate ready-state flow.
+- If only one player accepts, the UI should show that it is waiting for the other player.
+- If one player leaves after game over, the room stays open.
+- Scores reset to 0 for the new round.
+- Rematch performs a full reset: fresh snake positions, fresh food, fresh countdown, normal starting speed.
+- There is no special timeout behavior for rematch acceptance.
+
+## Assumptions
+- The same two currently connected players are the only players eligible to accept a rematch for that finished round.
+- If the room stays open after one player leaves, it returns to a valid waiting/lobby-like state according to current room lifecycle rules.
+- A rematch starts a brand-new round but does not require generating a new room code.
+
+## User Scenarios
+
+### Scenario 1: Both players want another round
+**As a player**, I want to quickly start another match with the same opponent after game over.
+
+#### Expected behavior
+- After the round ends, both players see a rematch option.
+- A player can accept/request rematch.
+- When both players have accepted, the system starts a fresh round in the same room.
+- The room code remains the same.
+
+### Scenario 2: One player accepts first
+**As a player**, I want to know when I am waiting for the other player to agree to a rematch.
+
+#### Expected behavior
+- If only one player accepts rematch, the UI shows a waiting state.
+- The other player can still choose whether to accept.
+- The round does not restart until both players accept.
+
+### Scenario 3: Start a rematch with a clean slate
+**As a player**, I want the rematch to feel like a brand-new round, not a continuation of the last one.
+
+#### Expected behavior
+- Scores reset to 0.
+- Snake positions reset.
+- Food resets.
+- Speed resets to the normal starting speed.
+- A fresh countdown appears before movement begins.
+
+### Scenario 4: One player leaves after the round ends
+**As a player**, I want the room to remain available if the other player leaves after game over.
+
+#### Expected behavior
+- If one player leaves after game over, the room remains open.
+- The remaining player does not get forced into room destruction solely because the other player left.
+- The room returns to a waiting/open state according to room rules.
+
+## Functional Requirements
+
+### Rematch request flow
+1. After a round ends, the system must present both players with a rematch option.
+2. The system must track rematch acceptance independently for each player.
+3. One player accepting rematch must not restart the round by itself.
+4. The system must restart the round only when both players have accepted rematch.
+5. The UI must show when a player is waiting for the other player to accept.
+
+### Room continuity
+6. A rematch must occur in the same room.
+7. The room code must remain unchanged for the rematch.
+8. The same connected players should remain associated with that room for the rematch flow.
+
+### Round reset behavior
+9. When a rematch starts, the system must fully reset round state.
+10. Scores must reset to 0.
+11. Snake positions and movement state must reset.
+12. Food state must reset to a fresh valid spawn.
+13. Speed progression must reset to the normal starting speed.
+14. The system must show the normal countdown before the rematch round begins.
+15. The rematch must begin without requiring the separate pre-game ready-state flow used for first-time room start.
+
+### Leave/disconnect behavior after game over
+16. If a player leaves after game over, the room must remain open.
+17. The remaining player must receive an updated room/rematch state.
+18. The system must clear any stale rematch acceptance that no longer applies once a player leaves.
+19. The room must return to a valid waiting/open state after such a leave event.
+
+### Timeout behavior
+20. The system must not enforce any special rematch timeout for MVP.
+21. A rematch request may remain pending until another player responds or room state changes.
+
+## Non-Functional Requirements
+- Rematch state must remain server-authoritative.
+- Reset behavior must be deterministic and consistent for both players.
+- The rematch flow must not require page refresh.
+- The same-room rematch should minimize friction relative to creating a new room.
+
+## Edge Cases
+- Both players click rematch at nearly the same time.
+- One player accepts rematch, then disconnects.
+- One player leaves after game over while the other is waiting on rematch.
+- A rematch starts only after both players have accepted, even if one acceptance was earlier.
+- Fresh round reset must not leak score, speed, or board state from the previous round.
+
+## Acceptance Criteria
+1. After game over, both players can see and use a rematch option.
+2. The round restarts only after both players accept rematch.
+3. If only one player accepts, the UI clearly shows that it is waiting for the other player.
+4. The rematch happens in the same room with the same room code.
+5. Starting a rematch resets scores to 0.
+6. Starting a rematch resets snakes, food, speed, and other round state.
+7. Starting a rematch shows a fresh countdown before movement begins.
+8. Rematch does not require going back through the separate ready-state flow.
+9. If one player leaves after game over, the room remains open.
+10. No special rematch timeout interrupts the waiting state.
+
+## Open Notes for Implementation
+- The UI should make rematch acceptance state obvious for both players.
+- Room/open-state behavior after a post-game leave should align with the existing room lifecycle introduced earlier, rather than inventing a separate room model.

--- a/docs/specs/replay-rematch-flow.md
+++ b/docs/specs/replay-rematch-flow.md
@@ -1,0 +1,139 @@
+# Feature Spec: Replay / Rematch Flow
+
+## Status
+Draft for stakeholder approval
+
+## Feature Summary
+As a player, I want to request a rematch with the same opponent in the same room after a round ends so that we can quickly play again without creating a new room from scratch.
+
+## Scope
+In scope for this feature:
+- post-game rematch UI
+- both-player rematch acceptance flow
+- waiting state when only one player accepts rematch
+- replay in the same room with the same room code
+- full round reset for rematch
+- score reset for the new round
+- fresh countdown before the rematch starts
+- room behavior when one player leaves after game over
+
+Out of scope for this feature:
+- matchmaking with a new opponent
+- persistent match history
+- timeout-based rematch expiration
+- ranked scoring or session totals across rounds
+- spectator support
+
+## Stakeholder Decisions Captured
+- Both players must accept the rematch.
+- Rematch stays in the same room with the same room code.
+- Once both players accept, the rematch starts directly without going back to a separate ready-state flow.
+- If only one player accepts, the UI should show that it is waiting for the other player.
+- If one player leaves after game over, the room stays open.
+- Scores reset to 0 for the new round.
+- Rematch performs a full reset: fresh snake positions, fresh food, fresh countdown, normal starting speed.
+- There is no special timeout behavior for rematch acceptance.
+
+## Assumptions
+- The same two currently connected players are the only players eligible to accept a rematch for that finished round.
+- If the room stays open after one player leaves, it returns to a valid waiting/lobby-like state according to current room lifecycle rules.
+- A rematch starts a brand-new round but does not require generating a new room code.
+
+## User Scenarios
+
+### Scenario 1: Both players want another round
+**As a player**, I want to quickly start another match with the same opponent after game over.
+
+#### Expected behavior
+- After the round ends, both players see a rematch option.
+- A player can accept/request rematch.
+- When both players have accepted, the system starts a fresh round in the same room.
+- The room code remains the same.
+
+### Scenario 2: One player accepts first
+**As a player**, I want to know when I am waiting for the other player to agree to a rematch.
+
+#### Expected behavior
+- If only one player accepts rematch, the UI shows a waiting state.
+- The other player can still choose whether to accept.
+- The round does not restart until both players accept.
+
+### Scenario 3: Start a rematch with a clean slate
+**As a player**, I want the rematch to feel like a brand-new round, not a continuation of the last one.
+
+#### Expected behavior
+- Scores reset to 0.
+- Snake positions reset.
+- Food resets.
+- Speed resets to the normal starting speed.
+- A fresh countdown appears before movement begins.
+
+### Scenario 4: One player leaves after the round ends
+**As a player**, I want the room to remain available if the other player leaves after game over.
+
+#### Expected behavior
+- If one player leaves after game over, the room remains open.
+- The remaining player does not get forced into room destruction solely because the other player left.
+- The room returns to a waiting/open state according to room rules.
+
+## Functional Requirements
+
+### Rematch request flow
+1. After a round ends, the system must present both players with a rematch option.
+2. The system must track rematch acceptance independently for each player.
+3. One player accepting rematch must not restart the round by itself.
+4. The system must restart the round only when both players have accepted rematch.
+5. The UI must show when a player is waiting for the other player to accept.
+
+### Room continuity
+6. A rematch must occur in the same room.
+7. The room code must remain unchanged for the rematch.
+8. The same connected players should remain associated with that room for the rematch flow.
+
+### Round reset behavior
+9. When a rematch starts, the system must fully reset round state.
+10. Scores must reset to 0.
+11. Snake positions and movement state must reset.
+12. Food state must reset to a fresh valid spawn.
+13. Speed progression must reset to the normal starting speed.
+14. The system must show the normal countdown before the rematch round begins.
+15. The rematch must begin without requiring the separate pre-game ready-state flow used for first-time room start.
+
+### Leave/disconnect behavior after game over
+16. If a player leaves after game over, the room must remain open.
+17. The remaining player must receive an updated room/rematch state.
+18. The system must clear any stale rematch acceptance that no longer applies once a player leaves.
+19. The room must return to a valid waiting/open state after such a leave event.
+
+### Timeout behavior
+20. The system must not enforce any special rematch timeout for MVP.
+21. A rematch request may remain pending until another player responds or room state changes.
+
+## Non-Functional Requirements
+- Rematch state must remain server-authoritative.
+- Reset behavior must be deterministic and consistent for both players.
+- The rematch flow must not require page refresh.
+- The same-room rematch should minimize friction relative to creating a new room.
+
+## Edge Cases
+- Both players click rematch at nearly the same time.
+- One player accepts rematch, then disconnects.
+- One player leaves after game over while the other is waiting on rematch.
+- A rematch starts only after both players have accepted, even if one acceptance was earlier.
+- Fresh round reset must not leak score, speed, or board state from the previous round.
+
+## Acceptance Criteria
+1. After game over, both players can see and use a rematch option.
+2. The round restarts only after both players accept rematch.
+3. If only one player accepts, the UI clearly shows that it is waiting for the other player.
+4. The rematch happens in the same room with the same room code.
+5. Starting a rematch resets scores to 0.
+6. Starting a rematch resets snakes, food, speed, and other round state.
+7. Starting a rematch shows a fresh countdown before movement begins.
+8. Rematch does not require going back through the separate ready-state flow.
+9. If one player leaves after game over, the room remains open.
+10. No special rematch timeout interrupts the waiting state.
+
+## Open Notes for Implementation
+- The UI should make rematch acceptance state obvious for both players.
+- Room/open-state behavior after a post-game leave should align with the existing room lifecycle introduced earlier, rather than inventing a separate room model.

--- a/public/app.js
+++ b/public/app.js
@@ -24,11 +24,15 @@ const score1El = document.getElementById('score1');
 const gameMessageEl = document.getElementById('gameMessage');
 const buildMarkerEl = document.getElementById('buildMarker');
 const gameBuildMarkerEl = document.getElementById('gameBuildMarker');
+const rematchPanelEl = document.getElementById('rematchPanel');
+const rematchStatusEl = document.getElementById('rematchStatus');
+const rematchButton = document.getElementById('rematchButton');
 
 let latestLobbyState = null;
 let latestGameState = null;
 let yourSlotIndex = null;
 let boardReady = false;
+let latestRematchState = null;
 let buildMarkerText = 'Build: loading…';
 let buildMarkerTitle = 'Build metadata is loading.';
 
@@ -59,6 +63,7 @@ socket.on('room:joined', (payload) => {
 socket.on('player:left', () => {
   statusEl.textContent = 'A player left. Waiting for a replacement.';
   gameStatusInlineEl.textContent = 'A player left. Waiting for a replacement.';
+  rematchStatusEl.textContent = 'Rematch cleared. Waiting for a replacement player.';
 });
 
 socket.on('lobby:state', (payload) => {
@@ -87,16 +92,25 @@ socket.on('game:start', (payload) => {
 
 socket.on('game:state', (payload) => {
   latestGameState = payload;
+  latestRematchState = { roomCode: payload.roomCode, phase: payload.phase, rematch: payload.rematch, version: payload.version };
   renderGame(payload);
+  renderRematch(payload.rematch, payload.phase);
 });
 
 socket.on('game:ended', (payload) => {
   latestGameState = payload.finalState;
+  latestRematchState = { roomCode: payload.roomCode, phase: payload.phase, rematch: payload.finalState.rematch, version: payload.version };
   renderGame(payload.finalState, payload.result.bySlot);
+  renderRematch(payload.finalState.rematch, payload.phase);
   const yourOutcome = yourSlotIndex === null ? 'draw' : payload.result.bySlot[yourSlotIndex];
   const statusText = yourOutcome === 'win' ? 'You win!' : yourOutcome === 'lose' ? 'You lose.' : 'Round ended in a draw.';
   statusEl.textContent = statusText;
   gameStatusInlineEl.textContent = statusText;
+});
+
+socket.on('game:rematch-state', (payload) => {
+  latestRematchState = payload;
+  renderRematch(payload.rematch, payload.phase, payload.message);
 });
 
 socket.on('room:closed', (payload) => {
@@ -134,6 +148,10 @@ async function copyActiveRoomCode() {
 
 document.getElementById('copyRoomCodeButton').addEventListener('click', copyActiveRoomCode);
 document.getElementById('copyGameRoomCodeButton').addEventListener('click', copyActiveRoomCode);
+rematchButton.addEventListener('click', () => {
+  if (!latestRematchState?.rematch?.available || latestRematchState.rematch.requestedByYou) return;
+  socket.emit('game:rematch-request');
+});
 
 readyButton.addEventListener('click', () => {
   if (!latestLobbyState) return;
@@ -211,9 +229,37 @@ function renderLobby(state) {
     gameMessageEl.textContent = state.phase === 'starting'
       ? 'Both players are ready. Transitioning into gameplay.'
       : state.phase === 'game-over'
-        ? 'Round finished. Lobby remains hidden while the result screen is shown.'
+        ? 'Round finished. Choose rematch or wait for room changes.'
         : 'Gameplay screen active. Lobby is fully hidden during the match.';
   }
+
+  renderRematch(state.rematch, state.phase);
+}
+
+function renderRematch(rematch, phase, message) {
+  const isPostGame = phase === 'game-over';
+  rematchPanelEl.classList.toggle('hidden', !isPostGame);
+  if (!isPostGame) return;
+
+  if (!rematch?.available) {
+    rematchStatusEl.textContent = message || 'Rematch unavailable until both players are present.';
+    rematchButton.textContent = 'Rematch unavailable';
+    rematchButton.disabled = true;
+    return;
+  }
+
+  if (rematch.bothAccepted) {
+    rematchStatusEl.textContent = 'Both players accepted. Starting a fresh countdown…';
+  } else if (rematch.waitingForOtherPlayer) {
+    rematchStatusEl.textContent = 'Rematch requested. Waiting for the other player.';
+  } else if (rematch.requestedBySlot[0] || rematch.requestedBySlot[1]) {
+    rematchStatusEl.textContent = 'Your opponent wants a rematch. Accept to restart in the same room.';
+  } else {
+    rematchStatusEl.textContent = message || 'Want another round? Accept rematch to stay in this room.';
+  }
+
+  rematchButton.textContent = rematch.requestedByYou ? 'Rematch requested' : 'Accept rematch';
+  rematchButton.disabled = rematch.requestedByYou || rematch.bothAccepted || !rematch.available;
 }
 
 function renderGame(state, perSlotResult) {

--- a/public/app.js
+++ b/public/app.js
@@ -27,6 +27,9 @@ const gameBuildMarkerEl = document.getElementById('gameBuildMarker');
 const rematchPanelEl = document.getElementById('rematchPanel');
 const rematchStatusEl = document.getElementById('rematchStatus');
 const rematchButton = document.getElementById('rematchButton');
+const postGameBannerEl = document.getElementById('postGameBanner');
+const postGameBannerStatusEl = document.getElementById('postGameBannerStatus');
+const postGameBannerButton = document.getElementById('postGameBannerButton');
 
 let latestLobbyState = null;
 let latestGameState = null;
@@ -148,10 +151,13 @@ async function copyActiveRoomCode() {
 
 document.getElementById('copyRoomCodeButton').addEventListener('click', copyActiveRoomCode);
 document.getElementById('copyGameRoomCodeButton').addEventListener('click', copyActiveRoomCode);
-rematchButton.addEventListener('click', () => {
+function requestRematch() {
   if (!latestRematchState?.rematch?.available || latestRematchState.rematch.requestedByYou) return;
   socket.emit('game:rematch-request');
-});
+}
+
+rematchButton.addEventListener('click', requestRematch);
+postGameBannerButton.addEventListener('click', requestRematch);
 
 readyButton.addEventListener('click', () => {
   if (!latestLobbyState) return;
@@ -239,27 +245,52 @@ function renderLobby(state) {
 function renderRematch(rematch, phase, message) {
   const isPostGame = phase === 'game-over';
   rematchPanelEl.classList.toggle('hidden', !isPostGame);
+  postGameBannerEl.classList.toggle('hidden', !isPostGame);
+  rematchPanelEl.classList.remove('highlighted');
+  postGameBannerButton.classList.remove('waiting', 'accepted');
   if (!isPostGame) return;
 
+  let statusText = message || 'Want another round? Accept rematch to stay in this room.';
+  let buttonText = 'Accept rematch';
+  let buttonDisabled = true;
+
   if (!rematch?.available) {
-    rematchStatusEl.textContent = message || 'Rematch unavailable until both players are present.';
-    rematchButton.textContent = 'Rematch unavailable';
-    rematchButton.disabled = true;
-    return;
-  }
-
-  if (rematch.bothAccepted) {
-    rematchStatusEl.textContent = 'Both players accepted. Starting a fresh countdown…';
+    statusText = message || 'Rematch unavailable until both players are present.';
+    buttonText = 'Rematch unavailable';
+  } else if (rematch.bothAccepted) {
+    statusText = 'Both players accepted. Starting a fresh countdown…';
+    buttonText = 'Rematch starting…';
+    postGameBannerButton.classList.add('accepted');
   } else if (rematch.waitingForOtherPlayer) {
-    rematchStatusEl.textContent = 'Rematch requested. Waiting for the other player.';
+    statusText = 'Rematch requested. Waiting for the other player.';
+    buttonText = 'Waiting for other player';
+    buttonDisabled = true;
+    rematchPanelEl.classList.add('highlighted');
+    postGameBannerButton.classList.add('waiting');
   } else if (rematch.requestedBySlot[0] || rematch.requestedBySlot[1]) {
-    rematchStatusEl.textContent = 'Your opponent wants a rematch. Accept to restart in the same room.';
+    statusText = 'Your opponent wants a rematch. Accept to restart in the same room.';
+    buttonText = 'Accept rematch now';
+    buttonDisabled = false;
+    rematchPanelEl.classList.add('highlighted');
   } else {
-    rematchStatusEl.textContent = message || 'Want another round? Accept rematch to stay in this room.';
+    statusText = message || 'Want another round? Accept rematch to stay in this room.';
+    buttonText = 'Accept rematch now';
+    buttonDisabled = false;
+    rematchPanelEl.classList.add('highlighted');
   }
 
-  rematchButton.textContent = rematch.requestedByYou ? 'Rematch requested' : 'Accept rematch';
-  rematchButton.disabled = rematch.requestedByYou || rematch.bothAccepted || !rematch.available;
+  if (rematch?.requestedByYou) {
+    buttonText = 'Rematch requested';
+    buttonDisabled = true;
+    postGameBannerButton.classList.add('waiting');
+  }
+
+  rematchStatusEl.textContent = statusText;
+  postGameBannerStatusEl.textContent = statusText;
+  rematchButton.textContent = buttonText;
+  postGameBannerButton.textContent = buttonText;
+  rematchButton.disabled = buttonDisabled;
+  postGameBannerButton.disabled = buttonDisabled;
 }
 
 function renderGame(state, perSlotResult) {

--- a/public/index.html
+++ b/public/index.html
@@ -68,6 +68,12 @@
             </aside>
 
             <div class="game-center">
+              <div id="postGameBanner" class="post-game-banner hidden" aria-live="polite">
+                <div class="eyebrow">Play again</div>
+                <h2 class="post-game-title">Rematch ready</h2>
+                <p id="postGameBannerStatus" class="info-copy post-game-copy">Want another round? Accept rematch to stay in this room.</p>
+                <button id="postGameBannerButton" class="post-game-button" type="button">Accept rematch</button>
+              </div>
               <div id="board" class="board" aria-label="Game board"></div>
               <p id="gameMessage" class="message game-message"></p>
             </div>

--- a/public/index.html
+++ b/public/index.html
@@ -53,6 +53,11 @@
                 <div id="gamePhaseLabel" class="game-phase">Waiting</div>
                 <p id="gameStatusInline" class="info-copy">Waiting for gameplay to begin.</p>
               </div>
+              <div id="rematchPanel" class="info-card rematch-card hidden">
+                <div class="eyebrow">Rematch</div>
+                <p id="rematchStatus" class="info-copy">Want another round? Accept rematch to stay in this room.</p>
+                <button id="rematchButton" type="button">Accept rematch</button>
+              </div>
               <div class="info-card compact-score-card">
                 <div class="eyebrow">Player 1</div>
                 <div class="score-card player-one solo-score-card">

--- a/public/styles.css
+++ b/public/styles.css
@@ -213,3 +213,46 @@ button:disabled { opacity: .6; cursor: not-allowed; }
 }
 
 .rematch-card button { width: 100%; }
+
+
+.rematch-card {
+  border-color: #475569;
+}
+.rematch-card.highlighted {
+  border-color: #22c55e;
+  box-shadow: 0 0 0 1px rgba(34, 197, 94, 0.35), 0 12px 32px rgba(15, 23, 42, 0.32);
+}
+.post-game-banner {
+  width: min(100%, 760px);
+  box-sizing: border-box;
+  padding: 18px;
+  border-radius: 16px;
+  border: 1px solid #22c55e;
+  background: linear-gradient(135deg, rgba(34, 197, 94, 0.18), rgba(15, 23, 42, 0.96));
+  box-shadow: 0 16px 40px rgba(0, 0, 0, 0.28);
+  display: grid;
+  gap: 10px;
+}
+.post-game-title {
+  margin: 0;
+  font-size: clamp(28px, 4vw, 36px);
+}
+.post-game-copy {
+  margin: 0;
+  font-size: 16px;
+}
+.post-game-button {
+  width: 100%;
+  min-height: 56px;
+  font-size: 18px;
+}
+.post-game-button.waiting,
+.post-game-button.accepted {
+  background: #0f172a;
+  color: #f8fafc;
+}
+@media (max-width: 860px) {
+  .post-game-banner {
+    order: -1;
+  }
+}

--- a/public/styles.css
+++ b/public/styles.css
@@ -211,3 +211,5 @@ button:disabled { opacity: .6; cursor: not-allowed; }
     width: fit-content;
   }
 }
+
+.rematch-card button { width: 100%; }

--- a/src/server/__tests__/roomService.test.ts
+++ b/src/server/__tests__/roomService.test.ts
@@ -1,109 +1,192 @@
-import { beforeEach, describe, expect, test, vi } from 'vitest';
-import { RoomService } from '../roomService.js';
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { RoomService } from "../roomService.js";
 
-function payloads(result: { events: Array<{ type: string; payload: unknown }> }, type: string) {
-  return result.events.filter((event) => event.type === type).map((event) => event.payload as any);
+function payloads(
+  result: { events: Array<{ type: string; payload: unknown }> },
+  type: string,
+) {
+  return result.events
+    .filter((event) => event.type === type)
+    .map((event) => event.payload as any);
 }
 
 function startGame(service: RoomService, roomCode: string) {
-  service.joinRoom('socket-b', roomCode);
-  service.setReady('socket-a', true);
-  service.setReady('socket-b', true);
+  service.joinRoom("socket-b", roomCode);
+  service.setReady("socket-a", true);
+  service.setReady("socket-b", true);
   vi.advanceTimersByTime(3000);
 }
 
 function finishGame(service: RoomService) {
   for (let step = 0; step < 25; step += 1) {
-    const result = service.setDirection('socket-a', 'up');
-    if (payloads(result, 'room:error').length === 0) break;
+    const result = service.setDirection("socket-a", "up");
+    if (payloads(result, "room:error").length === 0) break;
     vi.advanceTimersByTime(200);
   }
   vi.advanceTimersByTime(3200);
 }
 
-describe('RoomService', () => {
+describe("RoomService", () => {
   beforeEach(() => {
     vi.useFakeTimers();
-    vi.setSystemTime(new Date('2026-03-11T22:00:00Z'));
+    vi.setSystemTime(new Date("2026-03-11T22:00:00Z"));
   });
 
-  test('creates a room and sends an authoritative one-player lobby state', () => {
+  test("creates a room and sends an authoritative one-player lobby state", () => {
     const service = new RoomService();
-    const result = service.createRoom('socket-a');
+    const result = service.createRoom("socket-a");
 
-    const created = payloads(result, 'room:created')[0];
-    const lobbyState = payloads(result, 'lobby:state')[0];
+    const created = payloads(result, "room:created")[0];
+    const lobbyState = payloads(result, "lobby:state")[0];
 
     expect(created.roomCode).toMatch(/^[A-Z]{4}$/);
     expect(lobbyState.occupiedCount).toBe(1);
-    expect(lobbyState.phase).toBe('waiting-for-players');
+    expect(lobbyState.phase).toBe("waiting-for-players");
     expect(lobbyState.players[0].isOccupied).toBe(true);
     expect(lobbyState.players[1].isOccupied).toBe(false);
   });
 
-  test('starts with a real countdown before emitting game start', () => {
+  test("starts with a real countdown before emitting game start", () => {
     const emitted: Array<{ type: string; payload: any }> = [];
     const service = new RoomService();
     service.setEventSink((events) => emitted.push(...events));
 
-    const created = service.createRoom('socket-a');
-    const roomCode = payloads(created, 'room:created')[0].roomCode;
+    const created = service.createRoom("socket-a");
+    const roomCode = payloads(created, "room:created")[0].roomCode;
 
-    service.joinRoom('socket-b', roomCode.toLowerCase());
-    expect(payloads(service.setReady('socket-a', true), 'game:start')).toHaveLength(0);
+    service.joinRoom("socket-b", roomCode.toLowerCase());
+    expect(
+      payloads(service.setReady("socket-a", true), "game:start"),
+    ).toHaveLength(0);
 
-    const readyResult = service.setReady('socket-b', true);
-    expect(payloads(readyResult, 'game:start')).toHaveLength(0);
-    expect(payloads(readyResult, 'game:countdown')).toHaveLength(2);
-    expect(payloads(readyResult, 'game:state')[0].countdownSecondsRemaining).toBe(3);
-
-    vi.advanceTimersByTime(1000);
-    expect(emitted.filter((event) => event.type === 'game:countdown')).toHaveLength(2);
-    expect(emitted.filter((event) => event.type === 'game:countdown')[0].payload.secondsRemaining).toBe(2);
-
-    vi.advanceTimersByTime(1000);
-    expect(emitted.filter((event) => event.type === 'game:countdown')).toHaveLength(4);
-    expect(emitted.filter((event) => event.type === 'game:countdown')[2].payload.secondsRemaining).toBe(1);
+    const readyResult = service.setReady("socket-b", true);
+    expect(payloads(readyResult, "game:start")).toHaveLength(0);
+    expect(payloads(readyResult, "game:countdown")).toHaveLength(2);
+    expect(
+      payloads(readyResult, "game:state")[0].countdownSecondsRemaining,
+    ).toBe(3);
 
     vi.advanceTimersByTime(1000);
-    const gameStarts = emitted.filter((event) => event.type === 'game:start');
+    expect(
+      emitted.filter((event) => event.type === "game:countdown"),
+    ).toHaveLength(2);
+    expect(
+      emitted.filter((event) => event.type === "game:countdown")[0].payload
+        .secondsRemaining,
+    ).toBe(2);
+
+    vi.advanceTimersByTime(1000);
+    expect(
+      emitted.filter((event) => event.type === "game:countdown"),
+    ).toHaveLength(4);
+    expect(
+      emitted.filter((event) => event.type === "game:countdown")[2].payload
+        .secondsRemaining,
+    ).toBe(1);
+
+    vi.advanceTimersByTime(1000);
+    const gameStarts = emitted.filter((event) => event.type === "game:start");
     expect(gameStarts).toHaveLength(2);
-    expect(gameStarts[0].payload.phase).toBe('in-progress');
+    expect(gameStarts[0].payload.phase).toBe("in-progress");
   });
 
-  test('one-player rematch waiting state is authoritative', () => {
+  test("one-player rematch waiting state is authoritative", () => {
     const service = new RoomService();
-    const roomCode = payloads(service.createRoom('socket-a'), 'room:created')[0].roomCode;
+    const roomCode = payloads(service.createRoom("socket-a"), "room:created")[0]
+      .roomCode;
     startGame(service, roomCode);
     finishGame(service);
 
-    const rematchResult = service.requestRematch('socket-a');
-    const rematchState = payloads(rematchResult, 'game:rematch-state')[0];
+    const rematchResult = service.requestRematch("socket-a");
+    const rematchState = payloads(rematchResult, "game:rematch-state")[0];
 
-    expect(rematchState.phase).toBe('game-over');
-    expect(rematchState.rematch.status).toBe('waiting');
+    expect(rematchState.phase).toBe("game-over");
+    expect(rematchState.rematch.status).toBe("waiting");
     expect(rematchState.rematch.requestedBySlot[0]).toBe(true);
     expect(rematchState.rematch.requestedBySlot[1]).toBe(false);
     expect(rematchState.rematch.waitingForOtherPlayer).toBe(true);
   });
 
-  test('both-player acceptance starts a fresh countdown in the same room with a reset match state', () => {
+  test("duplicate rematch requests from the same player are a no-op", () => {
     const service = new RoomService();
-    const roomCode = payloads(service.createRoom('socket-a'), 'room:created')[0].roomCode;
+    const roomCode = payloads(service.createRoom("socket-a"), "room:created")[0]
+      .roomCode;
     startGame(service, roomCode);
     finishGame(service);
 
-    const firstAccept = service.requestRematch('socket-a');
-    const finalStateBefore = payloads(firstAccept, 'game:state').at(-1);
+    const firstAccept = service.requestRematch("socket-a");
+    const firstLobbyState = payloads(firstAccept, "lobby:state")[0];
+    const firstRematchState = payloads(firstAccept, "game:rematch-state")[0];
+    const duplicateAccept = service.requestRematch("socket-a");
+
+    expect(firstLobbyState.version).toBe(firstRematchState.version);
+    expect(duplicateAccept.events).toEqual([]);
+  });
+
+  test("rematch payload stays viewer-consistent across lobby, game, and rematch events", () => {
+    const service = new RoomService();
+    const roomCode = payloads(service.createRoom("socket-a"), "room:created")[0]
+      .roomCode;
+    startGame(service, roomCode);
+    finishGame(service);
+
+    const rematchResult = service.requestRematch("socket-a");
+    const lobbyStates = rematchResult.events.filter(
+      (event) => event.type === "lobby:state",
+    ) as Array<{ socketId: string; payload: any }>;
+    const gameStates = rematchResult.events.filter(
+      (event) => event.type === "game:state",
+    ) as Array<{ socketId: string; payload: any }>;
+    const rematchStates = rematchResult.events.filter(
+      (event) => event.type === "game:rematch-state",
+    ) as Array<{ socketId: string; payload: any }>;
+
+    const playerAView = {
+      lobby: lobbyStates.find((event) => event.socketId === "socket-a")?.payload
+        .rematch,
+      game: gameStates.find((event) => event.socketId === "socket-a")?.payload
+        .rematch,
+      rematch: rematchStates.find((event) => event.socketId === "socket-a")
+        ?.payload.rematch,
+    };
+    const playerBView = {
+      lobby: lobbyStates.find((event) => event.socketId === "socket-b")?.payload
+        .rematch,
+      game: gameStates.find((event) => event.socketId === "socket-b")?.payload
+        .rematch,
+      rematch: rematchStates.find((event) => event.socketId === "socket-b")
+        ?.payload.rematch,
+    };
+
+    expect(playerAView.lobby).toEqual(playerAView.game);
+    expect(playerAView.game).toEqual(playerAView.rematch);
+    expect(playerAView.lobby.requestedByYou).toBe(true);
+    expect(playerAView.lobby.waitingForOtherPlayer).toBe(true);
+
+    expect(playerBView.lobby).toEqual(playerBView.game);
+    expect(playerBView.game).toEqual(playerBView.rematch);
+    expect(playerBView.lobby.requestedByYou).toBe(false);
+    expect(playerBView.lobby.waitingForOtherPlayer).toBe(false);
+  });
+
+  test("both-player acceptance starts a fresh countdown in the same room with a reset match state", () => {
+    const service = new RoomService();
+    const roomCode = payloads(service.createRoom("socket-a"), "room:created")[0]
+      .roomCode;
+    startGame(service, roomCode);
+    finishGame(service);
+
+    const firstAccept = service.requestRematch("socket-a");
+    const finalStateBefore = payloads(firstAccept, "game:state").at(-1);
     finalStateBefore.snakes[0].score = 9;
 
-    const secondAccept = service.requestRematch('socket-b');
-    const countdown = payloads(secondAccept, 'game:countdown');
-    const gameState = payloads(secondAccept, 'game:state').at(-1);
+    const secondAccept = service.requestRematch("socket-b");
+    const countdown = payloads(secondAccept, "game:countdown");
+    const gameState = payloads(secondAccept, "game:state").at(-1);
 
     expect(countdown).toHaveLength(2);
     expect(countdown[0].roomCode).toBe(roomCode);
-    expect(gameState.phase).toBe('starting');
+    expect(gameState.phase).toBe("starting");
     expect(gameState.tickNumber).toBe(0);
     expect(gameState.tickIntervalMs).toBe(200);
     expect(gameState.foodsEaten).toBe(0);
@@ -122,63 +205,66 @@ describe('RoomService', () => {
     expect(gameState.food).not.toBeNull();
   });
 
-  test('post-game leave keeps the room open and clears stale rematch state', () => {
+  test("post-game leave keeps the room open and clears stale rematch state", () => {
     const service = new RoomService();
-    const roomCode = payloads(service.createRoom('socket-a'), 'room:created')[0].roomCode;
+    const roomCode = payloads(service.createRoom("socket-a"), "room:created")[0]
+      .roomCode;
     startGame(service, roomCode);
     finishGame(service);
-    service.requestRematch('socket-a');
+    service.requestRematch("socket-a");
 
-    const leaveResult = service.disconnect('socket-b');
-    const left = payloads(leaveResult, 'player:left')[0];
-    const lobby = payloads(leaveResult, 'lobby:state')[0];
-    const rematch = payloads(leaveResult, 'game:rematch-state')[0];
+    const leaveResult = service.disconnect("socket-b");
+    const left = payloads(leaveResult, "player:left")[0];
+    const lobby = payloads(leaveResult, "lobby:state")[0];
+    const rematch = payloads(leaveResult, "game:rematch-state")[0];
 
-    expect(left.reason).toBe('disconnected');
-    expect(lobby.phase).toBe('waiting-for-players');
+    expect(left.reason).toBe("disconnected");
+    expect(lobby.phase).toBe("waiting-for-players");
     expect(lobby.roomCode).toBe(roomCode);
     expect(rematch.rematch.available).toBe(false);
     expect(rematch.rematch.requestedBySlot[0]).toBe(false);
     expect(rematch.rematch.requestedBySlot[1]).toBe(false);
   });
 
-  test('replacement join after post-game leave returns room to normal lobby flow', () => {
+  test("replacement join after post-game leave returns room to normal lobby flow", () => {
     const service = new RoomService();
-    const roomCode = payloads(service.createRoom('socket-a'), 'room:created')[0].roomCode;
+    const roomCode = payloads(service.createRoom("socket-a"), "room:created")[0]
+      .roomCode;
     startGame(service, roomCode);
     finishGame(service);
-    service.disconnect('socket-b');
+    service.disconnect("socket-b");
 
-    const joinResult = service.joinRoom('socket-c', roomCode);
-    const lobby = payloads(joinResult, 'lobby:state').at(-1);
+    const joinResult = service.joinRoom("socket-c", roomCode);
+    const lobby = payloads(joinResult, "lobby:state").at(-1);
 
-    expect(lobby.phase).toBe('lobby');
+    expect(lobby.phase).toBe("lobby");
     expect(lobby.roomCode).toBe(roomCode);
     expect(lobby.rematch.available).toBe(false);
     expect(lobby.players[1].isOccupied).toBe(true);
     expect(lobby.canStart).toBe(false);
   });
 
-  test('disconnect during gameplay ends the round but does not close the room', () => {
+  test("disconnect during gameplay ends the round but does not close the room", () => {
     const emitted: Array<{ type: string; payload: any }> = [];
     const service = new RoomService();
     service.setEventSink((events) => emitted.push(...events));
 
-    const roomCode = payloads(service.createRoom('socket-a'), 'room:created')[0].roomCode;
-    service.joinRoom('socket-b', roomCode);
-    service.setReady('socket-a', true);
-    service.setReady('socket-b', true);
+    const roomCode = payloads(service.createRoom("socket-a"), "room:created")[0]
+      .roomCode;
+    service.joinRoom("socket-b", roomCode);
+    service.setReady("socket-a", true);
+    service.setReady("socket-b", true);
     vi.advanceTimersByTime(3000);
 
-    const disconnectResult = service.disconnect('socket-b');
-    const ended = payloads(disconnectResult, 'game:ended');
+    const disconnectResult = service.disconnect("socket-b");
+    const ended = payloads(disconnectResult, "game:ended");
     expect(ended).toHaveLength(1);
     expect(ended[0].result.winnerSlotIndex).toBe(0);
-    expect(ended[0].result.bySlot[0]).toBe('win');
-    expect(ended[0].result.bySlot[1]).toBe('lose');
+    expect(ended[0].result.bySlot[0]).toBe("win");
+    expect(ended[0].result.bySlot[1]).toBe("lose");
 
     vi.advanceTimersByTime(3000);
-    const roomClosed = emitted.filter((event) => event.type === 'room:closed');
+    const roomClosed = emitted.filter((event) => event.type === "room:closed");
     expect(roomClosed).toHaveLength(0);
   });
 });

--- a/src/server/__tests__/roomService.test.ts
+++ b/src/server/__tests__/roomService.test.ts
@@ -5,6 +5,22 @@ function payloads(result: { events: Array<{ type: string; payload: unknown }> },
   return result.events.filter((event) => event.type === type).map((event) => event.payload as any);
 }
 
+function startGame(service: RoomService, roomCode: string) {
+  service.joinRoom('socket-b', roomCode);
+  service.setReady('socket-a', true);
+  service.setReady('socket-b', true);
+  vi.advanceTimersByTime(3000);
+}
+
+function finishGame(service: RoomService) {
+  for (let step = 0; step < 25; step += 1) {
+    const result = service.setDirection('socket-a', 'up');
+    if (payloads(result, 'room:error').length === 0) break;
+    vi.advanceTimersByTime(200);
+  }
+  vi.advanceTimersByTime(3200);
+}
+
 describe('RoomService', () => {
   beforeEach(() => {
     vi.useFakeTimers();
@@ -55,7 +71,95 @@ describe('RoomService', () => {
     expect(gameStarts[0].payload.phase).toBe('in-progress');
   });
 
-  test('disconnect during gameplay ends the round and closes the room', () => {
+  test('one-player rematch waiting state is authoritative', () => {
+    const service = new RoomService();
+    const roomCode = payloads(service.createRoom('socket-a'), 'room:created')[0].roomCode;
+    startGame(service, roomCode);
+    finishGame(service);
+
+    const rematchResult = service.requestRematch('socket-a');
+    const rematchState = payloads(rematchResult, 'game:rematch-state')[0];
+
+    expect(rematchState.phase).toBe('game-over');
+    expect(rematchState.rematch.status).toBe('waiting');
+    expect(rematchState.rematch.requestedBySlot[0]).toBe(true);
+    expect(rematchState.rematch.requestedBySlot[1]).toBe(false);
+    expect(rematchState.rematch.waitingForOtherPlayer).toBe(true);
+  });
+
+  test('both-player acceptance starts a fresh countdown in the same room with a reset match state', () => {
+    const service = new RoomService();
+    const roomCode = payloads(service.createRoom('socket-a'), 'room:created')[0].roomCode;
+    startGame(service, roomCode);
+    finishGame(service);
+
+    const firstAccept = service.requestRematch('socket-a');
+    const finalStateBefore = payloads(firstAccept, 'game:state').at(-1);
+    finalStateBefore.snakes[0].score = 9;
+
+    const secondAccept = service.requestRematch('socket-b');
+    const countdown = payloads(secondAccept, 'game:countdown');
+    const gameState = payloads(secondAccept, 'game:state').at(-1);
+
+    expect(countdown).toHaveLength(2);
+    expect(countdown[0].roomCode).toBe(roomCode);
+    expect(gameState.phase).toBe('starting');
+    expect(gameState.tickNumber).toBe(0);
+    expect(gameState.tickIntervalMs).toBe(200);
+    expect(gameState.foodsEaten).toBe(0);
+    expect(gameState.snakes[0].score).toBe(0);
+    expect(gameState.snakes[1].score).toBe(0);
+    expect(gameState.snakes[0].body).toEqual([
+      { x: 7, y: 15 },
+      { x: 6, y: 15 },
+      { x: 5, y: 15 },
+    ]);
+    expect(gameState.snakes[1].body).toEqual([
+      { x: 22, y: 15 },
+      { x: 23, y: 15 },
+      { x: 24, y: 15 },
+    ]);
+    expect(gameState.food).not.toBeNull();
+  });
+
+  test('post-game leave keeps the room open and clears stale rematch state', () => {
+    const service = new RoomService();
+    const roomCode = payloads(service.createRoom('socket-a'), 'room:created')[0].roomCode;
+    startGame(service, roomCode);
+    finishGame(service);
+    service.requestRematch('socket-a');
+
+    const leaveResult = service.disconnect('socket-b');
+    const left = payloads(leaveResult, 'player:left')[0];
+    const lobby = payloads(leaveResult, 'lobby:state')[0];
+    const rematch = payloads(leaveResult, 'game:rematch-state')[0];
+
+    expect(left.reason).toBe('disconnected');
+    expect(lobby.phase).toBe('waiting-for-players');
+    expect(lobby.roomCode).toBe(roomCode);
+    expect(rematch.rematch.available).toBe(false);
+    expect(rematch.rematch.requestedBySlot[0]).toBe(false);
+    expect(rematch.rematch.requestedBySlot[1]).toBe(false);
+  });
+
+  test('replacement join after post-game leave returns room to normal lobby flow', () => {
+    const service = new RoomService();
+    const roomCode = payloads(service.createRoom('socket-a'), 'room:created')[0].roomCode;
+    startGame(service, roomCode);
+    finishGame(service);
+    service.disconnect('socket-b');
+
+    const joinResult = service.joinRoom('socket-c', roomCode);
+    const lobby = payloads(joinResult, 'lobby:state').at(-1);
+
+    expect(lobby.phase).toBe('lobby');
+    expect(lobby.roomCode).toBe(roomCode);
+    expect(lobby.rematch.available).toBe(false);
+    expect(lobby.players[1].isOccupied).toBe(true);
+    expect(lobby.canStart).toBe(false);
+  });
+
+  test('disconnect during gameplay ends the round but does not close the room', () => {
     const emitted: Array<{ type: string; payload: any }> = [];
     const service = new RoomService();
     service.setEventSink((events) => emitted.push(...events));
@@ -75,7 +179,6 @@ describe('RoomService', () => {
 
     vi.advanceTimersByTime(3000);
     const roomClosed = emitted.filter((event) => event.type === 'room:closed');
-    expect(roomClosed).toHaveLength(1);
-    expect(roomClosed[0].payload.reason).toBe('player-disconnected');
+    expect(roomClosed).toHaveLength(0);
   });
 });

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -66,6 +66,10 @@ io.on('connection', (socket) => {
     emitEvents(roomService.setDirection(socket.id, payload.direction));
   });
 
+  socket.on(EVENTS.gameRematchRequest, () => {
+    emitEvents(roomService.requestRematch(socket.id).events);
+  });
+
   socket.on('disconnect', () => {
     emitEvents(roomService.disconnect(socket.id).events);
   });

--- a/src/server/roomService.ts
+++ b/src/server/roomService.ts
@@ -2,11 +2,13 @@ import type {
   Direction,
   GameCountdownPayload,
   GameEndedPayload,
+  GameRematchStatePayload,
   GameStartPayload,
   GameStatePayload,
   LobbyErrorReason,
   LobbyStatePayload,
   PlayerLeftPayload,
+  RematchView,
   RoomClosedPayload,
   RoomCreatedPayload,
   RoomJoinedPayload,
@@ -29,6 +31,10 @@ interface PlayerSlot {
   ready: boolean;
 }
 
+interface RematchState {
+  requestedBySlot: { 0: boolean; 1: boolean };
+}
+
 interface RoomRecord {
   roomCode: string;
   phase: RoomPhase;
@@ -38,6 +44,7 @@ interface RoomRecord {
   match: MatchState | null;
   countdown: { startedAt: number; endsAt: number; secondsRemaining: 3 | 2 | 1 | 0 } | null;
   teardownAt: number | null;
+  rematch: RematchState;
 }
 
 export interface ClientEvent {
@@ -51,6 +58,7 @@ export interface ClientEvent {
     | 'game:start'
     | 'game:state'
     | 'game:ended'
+    | 'game:rematch-state'
     | 'room:closed';
   socketId: string;
   payload: unknown;
@@ -91,6 +99,7 @@ export class RoomService {
       match: null,
       countdown: null,
       teardownAt: null,
+      rematch: { requestedBySlot: { 0: false, 1: false } },
       players: [
         { slotIndex: 0, playerId, socketId, connected: true, ready: false },
         { slotIndex: 1, playerId: null, socketId: null, connected: false, ready: false },
@@ -117,7 +126,10 @@ export class RoomService {
 
     const room = this.rooms.get(roomCode);
     if (!room) return { events: [this.error(socketId, 'ROOM_NOT_FOUND')] };
-    if (room.phase === 'starting' || room.phase === 'in-progress' || room.phase === 'game-over') {
+    if (room.phase === 'starting' || room.phase === 'in-progress') {
+      return { events: [this.error(socketId, 'GAME_ALREADY_STARTED')] };
+    }
+    if (room.phase === 'game-over' && room.players.every((player) => player.playerId)) {
       return { events: [this.error(socketId, 'GAME_ALREADY_STARTED')] };
     }
 
@@ -131,6 +143,7 @@ export class RoomService {
     emptySlot.ready = false;
     this.socketToRoom.set(socketId, roomCode);
     this.socketToPlayer.set(socketId, playerId);
+    this.clearRematchState(room);
     room.version += 1;
     room.phase = this.computePhase(room);
 
@@ -156,6 +169,44 @@ export class RoomService {
     room.phase = this.computePhase(room);
 
     return { events: this.afterLobbyMutation(room) };
+  }
+
+  requestRematch(socketId: string): ServiceResult {
+    const room = this.getRoomForSocket(socketId);
+    if (!room || room.phase !== 'game-over') return { events: [this.error(socketId, 'ACTION_NOT_ALLOWED')] };
+
+    const player = room.players.find((slot) => slot.socketId === socketId);
+    if (!player) return { events: [this.error(socketId, 'ACTION_NOT_ALLOWED')] };
+
+    room.rematch.requestedBySlot[player.slotIndex] = true;
+    room.version += 1;
+
+    const events = [
+      ...this.buildLobbyStateEvents(room),
+      ...this.buildGameStateEvents(room),
+      ...this.buildRematchStateEvents(room),
+    ];
+
+    if (!this.areBothPlayersPresent(room) || !room.rematch.requestedBySlot[0] || !room.rematch.requestedBySlot[1]) {
+      return { events };
+    }
+
+    room.phase = 'starting';
+    room.version += 1;
+    room.match = createInitialMatchState(room.roomCode);
+    room.countdown = null;
+    room.teardownAt = null;
+    room.players.forEach((slot) => { slot.ready = false; });
+    this.clearRematchState(room);
+
+    const now = Date.now();
+    room.countdown = { startedAt: now, endsAt: now + 3000, secondsRemaining: 3 };
+    events.push(...this.buildLobbyStateEvents(room));
+    events.push(...this.buildGameStateEvents(room, 3));
+    events.push(...this.buildCountdownEvents(room, 3, now));
+    events.push(...this.buildRematchStateEvents(room));
+    this.startCountdown(room.roomCode);
+    return { events };
   }
 
   setDirection(socketId: string, direction: Direction): ServiceResult {
@@ -205,6 +256,12 @@ export class RoomService {
     }
 
     remainingPlayers[0].ready = false;
+    this.clearRematchState(room);
+    room.countdown = null;
+    if (room.phase === 'game-over') {
+      room.match = null;
+      room.teardownAt = null;
+    }
     room.version += 1;
     room.phase = 'waiting-for-players';
 
@@ -212,6 +269,7 @@ export class RoomService {
       { type: 'player:left', socketId: slot.socketId!, payload: { roomCode, slotIndex, reason } satisfies PlayerLeftPayload },
     ]);
     events.push(...this.buildLobbyStateEvents(room));
+    events.push(...this.buildRematchStateEvents(room));
     return { events };
   }
 
@@ -222,11 +280,14 @@ export class RoomService {
     room.phase = 'starting';
     room.version += 1;
     room.match = createInitialMatchState(room.roomCode);
+    room.countdown = null;
+    this.clearRematchState(room);
     const now = Date.now();
     room.countdown = { startedAt: now, endsAt: now + 3000, secondsRemaining: 3 };
     events.push(...this.buildLobbyStateEvents(room));
     events.push(...this.buildGameStateEvents(room, 3));
     events.push(...this.buildCountdownEvents(room, 3, now));
+    events.push(...this.buildRematchStateEvents(room));
 
     this.startCountdown(room.roomCode);
     return events;
@@ -249,6 +310,7 @@ export class RoomService {
           ...this.buildLobbyStateEvents(activeRoom),
           ...this.buildGameStateEvents(activeRoom, second),
           ...this.buildCountdownEvents(activeRoom, second, now),
+          ...this.buildRematchStateEvents(activeRoom),
         ];
         if (second === 0) {
           events.push(...this.beginActiveMatch(activeRoom, now));
@@ -309,7 +371,8 @@ export class RoomService {
     room.match = match;
     room.phase = 'game-over';
     room.version += 1;
-    room.teardownAt = Date.now() + 3000;
+    room.teardownAt = null;
+    this.clearRematchState(room);
     this.cancelRuntime(room.roomCode);
 
     const finalState = this.serializeGameState(room);
@@ -331,29 +394,10 @@ export class RoomService {
 
     const events = this.buildLobbyStateEvents(room);
     events.push(...this.buildGameStateEvents(room));
+    events.push(...this.buildRematchStateEvents(room, closeReason === 'player-disconnected' ? 'Opponent disconnected. Room stays open for another player.' : 'Round complete. Choose rematch to play again.'));
     for (const player of room.players) {
       if (player.socketId) events.push({ type: 'game:ended', socketId: player.socketId, payload });
     }
-
-    const runtime: RuntimeRecord = { countdownTimers: [], tickTimer: null, teardownTimer: null };
-    runtime.teardownTimer = setTimeout(() => {
-      const activeRoom = this.rooms.get(room.roomCode);
-      if (!activeRoom) return;
-      const closeEvents: ClientEvent[] = [];
-      for (const player of activeRoom.players) {
-        if (!player.socketId) continue;
-        closeEvents.push({
-          type: 'room:closed',
-          socketId: player.socketId,
-          payload: { roomCode: activeRoom.roomCode, reason: closeReason, version: activeRoom.version } satisfies RoomClosedPayload,
-        });
-        this.socketToRoom.delete(player.socketId);
-        this.socketToPlayer.delete(player.socketId);
-      }
-      this.disposeRoom(activeRoom.roomCode);
-      this.emitExternal(closeEvents);
-    }, 3000);
-    this.runtimes.set(room.roomCode, runtime);
 
     return events;
   }
@@ -376,6 +420,22 @@ export class RoomService {
     return room.players.flatMap((player) => {
       if (!player.socketId) return [];
       return [{ type: 'lobby:state' as const, socketId: player.socketId, payload: this.serializeLobbyState(room, player.socketId) }];
+    });
+  }
+
+  private buildRematchStateEvents(room: RoomRecord, message?: string): ClientEvent[] {
+    const phase = room.phase === 'in-progress' ? null : room.phase;
+    if (!phase) return [];
+    return room.players.flatMap((player) => {
+      if (!player.socketId) return [];
+      const payload: GameRematchStatePayload = {
+        roomCode: room.roomCode,
+        phase,
+        rematch: this.buildRematchView(room, player.socketId),
+        version: room.version,
+        message,
+      };
+      return [{ type: 'game:rematch-state' as const, socketId: player.socketId, payload }];
     });
   }
 
@@ -420,6 +480,7 @@ export class RoomService {
       canStart,
       version: room.version,
       message: this.getLobbyMessage(room),
+      rematch: this.buildRematchView(room, viewerSocketId),
     };
   }
 
@@ -448,14 +509,42 @@ export class RoomService {
             deathReasons: match.deathReasons,
           }
         : undefined,
+      rematch: this.buildRematchView(room),
       version: room.version,
+    };
+  }
+
+  private buildRematchView(room: RoomRecord, viewerSocketId?: string): RematchView {
+    const eligiblePlayerCount = room.players.filter((player) => player.playerId && player.connected).length as 0 | 1 | 2;
+    const bothAccepted = eligiblePlayerCount === 2 && room.rematch.requestedBySlot[0] && room.rematch.requestedBySlot[1];
+    const acceptedCount = Number(room.rematch.requestedBySlot[0]) + Number(room.rematch.requestedBySlot[1]);
+    const available = room.phase === 'game-over' && eligiblePlayerCount === 2;
+    const viewer = viewerSocketId ? room.players.find((slot) => slot.socketId === viewerSocketId) : null;
+    const requestedByYou = viewer ? room.rematch.requestedBySlot[viewer.slotIndex] : false;
+    const waitingForOtherPlayer = available && requestedByYou && !bothAccepted;
+    const status = !available
+      ? 'unavailable'
+      : bothAccepted
+        ? 'accepted'
+        : acceptedCount === 1
+          ? 'waiting'
+          : 'idle';
+
+    return {
+      available,
+      status,
+      requestedBySlot: { ...room.rematch.requestedBySlot },
+      requestedByYou,
+      waitingForOtherPlayer,
+      bothAccepted,
+      eligiblePlayerCount,
     };
   }
 
   private getLobbyMessage(room: RoomRecord): string {
     if (room.phase === 'starting' && room.countdown) return `Match starts in ${room.countdown.secondsRemaining}…`;
     if (room.phase === 'in-progress') return 'Match in progress.';
-    if (room.phase === 'game-over') return 'Round complete. Room will close shortly.';
+    if (room.phase === 'game-over') return this.buildRematchView(room).available ? 'Round complete. Choose rematch to play again.' : 'Round complete. Waiting for opponent status to change.';
     return room.players.filter((player) => player.playerId).length === 2
       ? 'Game starts automatically when both players are ready.'
       : 'Waiting for opponent.';
@@ -469,6 +558,15 @@ export class RoomService {
     const occupiedCount = room.players.filter((player) => player.playerId).length;
     if (occupiedCount < 2) return 'waiting-for-players';
     return 'lobby';
+  }
+
+  private areBothPlayersPresent(room: RoomRecord): boolean {
+    return room.players.every((player) => player.playerId && player.connected && player.socketId);
+  }
+
+  private clearRematchState(room: RoomRecord) {
+    room.rematch.requestedBySlot[0] = false;
+    room.rematch.requestedBySlot[1] = false;
   }
 
   private getRoomForSocket(socketId: string): RoomRecord | undefined {

--- a/src/server/roomService.ts
+++ b/src/server/roomService.ts
@@ -13,7 +13,7 @@ import type {
   RoomCreatedPayload,
   RoomJoinedPayload,
   RoomPhase,
-} from '../shared/contracts.js';
+} from "../shared/contracts.js";
 import {
   applyDisconnectResult,
   advanceOneTick,
@@ -21,7 +21,7 @@ import {
   queueDirectionInput,
   toOutcomeForSlot,
   type MatchState,
-} from './gameLogic.js';
+} from "./gameLogic.js";
 
 interface PlayerSlot {
   slotIndex: 0 | 1;
@@ -42,24 +42,28 @@ interface RoomRecord {
   players: [PlayerSlot, PlayerSlot];
   version: number;
   match: MatchState | null;
-  countdown: { startedAt: number; endsAt: number; secondsRemaining: 3 | 2 | 1 | 0 } | null;
+  countdown: {
+    startedAt: number;
+    endsAt: number;
+    secondsRemaining: 3 | 2 | 1 | 0;
+  } | null;
   teardownAt: number | null;
   rematch: RematchState;
 }
 
 export interface ClientEvent {
   type:
-    | 'room:created'
-    | 'room:joined'
-    | 'lobby:state'
-    | 'room:error'
-    | 'player:left'
-    | 'game:countdown'
-    | 'game:start'
-    | 'game:state'
-    | 'game:ended'
-    | 'game:rematch-state'
-    | 'room:closed';
+    | "room:created"
+    | "room:joined"
+    | "lobby:state"
+    | "room:error"
+    | "player:left"
+    | "game:countdown"
+    | "game:start"
+    | "game:state"
+    | "game:ended"
+    | "game:rematch-state"
+    | "room:closed";
   socketId: string;
   payload: unknown;
 }
@@ -87,13 +91,13 @@ export class RoomService {
   }
 
   createRoom(socketId: string): ServiceResult {
-    this.leaveCurrentRoom(socketId, 'left');
+    this.leaveCurrentRoom(socketId, "left");
 
     const roomCode = this.generateUniqueRoomCode();
     const playerId = this.allocatePlayerId();
     const room: RoomRecord = {
       roomCode,
-      phase: 'waiting-for-players',
+      phase: "waiting-for-players",
       createdAt: Date.now(),
       version: 1,
       match: null,
@@ -102,7 +106,13 @@ export class RoomService {
       rematch: { requestedBySlot: { 0: false, 1: false } },
       players: [
         { slotIndex: 0, playerId, socketId, connected: true, ready: false },
-        { slotIndex: 1, playerId: null, socketId: null, connected: false, ready: false },
+        {
+          slotIndex: 1,
+          playerId: null,
+          socketId: null,
+          connected: false,
+          ready: false,
+        },
       ],
     };
 
@@ -112,29 +122,37 @@ export class RoomService {
 
     return {
       events: [
-        { type: 'room:created', socketId, payload: { roomCode, yourSlotIndex: 0 } satisfies RoomCreatedPayload },
+        {
+          type: "room:created",
+          socketId,
+          payload: { roomCode, yourSlotIndex: 0 } satisfies RoomCreatedPayload,
+        },
         ...this.buildLobbyStateEvents(room),
       ],
     };
   }
 
   joinRoom(socketId: string, rawRoomCode: string): ServiceResult {
-    this.leaveCurrentRoom(socketId, 'left');
+    this.leaveCurrentRoom(socketId, "left");
 
     const roomCode = this.normalizeRoomCode(rawRoomCode);
-    if (!this.isValidRoomCode(roomCode)) return { events: [this.error(socketId, 'INVALID_ROOM_CODE')] };
+    if (!this.isValidRoomCode(roomCode))
+      return { events: [this.error(socketId, "INVALID_ROOM_CODE")] };
 
     const room = this.rooms.get(roomCode);
-    if (!room) return { events: [this.error(socketId, 'ROOM_NOT_FOUND')] };
-    if (room.phase === 'starting' || room.phase === 'in-progress') {
-      return { events: [this.error(socketId, 'GAME_ALREADY_STARTED')] };
+    if (!room) return { events: [this.error(socketId, "ROOM_NOT_FOUND")] };
+    if (room.phase === "starting" || room.phase === "in-progress") {
+      return { events: [this.error(socketId, "GAME_ALREADY_STARTED")] };
     }
-    if (room.phase === 'game-over' && room.players.every((player) => player.playerId)) {
-      return { events: [this.error(socketId, 'GAME_ALREADY_STARTED')] };
+    if (
+      room.phase === "game-over" &&
+      room.players.every((player) => player.playerId)
+    ) {
+      return { events: [this.error(socketId, "GAME_ALREADY_STARTED")] };
     }
 
     const emptySlot = room.players.find((player) => !player.playerId);
-    if (!emptySlot) return { events: [this.error(socketId, 'ROOM_FULL')] };
+    if (!emptySlot) return { events: [this.error(socketId, "ROOM_FULL")] };
 
     const playerId = this.allocatePlayerId();
     emptySlot.playerId = playerId;
@@ -149,7 +167,14 @@ export class RoomService {
 
     return {
       events: [
-        { type: 'room:joined', socketId, payload: { roomCode, yourSlotIndex: emptySlot.slotIndex } satisfies RoomJoinedPayload },
+        {
+          type: "room:joined",
+          socketId,
+          payload: {
+            roomCode,
+            yourSlotIndex: emptySlot.slotIndex,
+          } satisfies RoomJoinedPayload,
+        },
         ...this.afterLobbyMutation(room),
       ],
     };
@@ -157,12 +182,16 @@ export class RoomService {
 
   setReady(socketId: string, ready: boolean): ServiceResult {
     const room = this.getRoomForSocket(socketId);
-    if (!room || (room.phase !== 'waiting-for-players' && room.phase !== 'lobby')) {
-      return { events: [this.error(socketId, 'ACTION_NOT_ALLOWED')] };
+    if (
+      !room ||
+      (room.phase !== "waiting-for-players" && room.phase !== "lobby")
+    ) {
+      return { events: [this.error(socketId, "ACTION_NOT_ALLOWED")] };
     }
 
     const player = room.players.find((slot) => slot.socketId === socketId);
-    if (!player) return { events: [this.error(socketId, 'ACTION_NOT_ALLOWED')] };
+    if (!player)
+      return { events: [this.error(socketId, "ACTION_NOT_ALLOWED")] };
 
     player.ready = ready;
     room.version += 1;
@@ -173,10 +202,16 @@ export class RoomService {
 
   requestRematch(socketId: string): ServiceResult {
     const room = this.getRoomForSocket(socketId);
-    if (!room || room.phase !== 'game-over') return { events: [this.error(socketId, 'ACTION_NOT_ALLOWED')] };
+    if (!room || room.phase !== "game-over")
+      return { events: [this.error(socketId, "ACTION_NOT_ALLOWED")] };
 
     const player = room.players.find((slot) => slot.socketId === socketId);
-    if (!player) return { events: [this.error(socketId, 'ACTION_NOT_ALLOWED')] };
+    if (!player)
+      return { events: [this.error(socketId, "ACTION_NOT_ALLOWED")] };
+
+    if (room.rematch.requestedBySlot[player.slotIndex]) {
+      return { events: [] };
+    }
 
     room.rematch.requestedBySlot[player.slotIndex] = true;
     room.version += 1;
@@ -187,20 +222,30 @@ export class RoomService {
       ...this.buildRematchStateEvents(room),
     ];
 
-    if (!this.areBothPlayersPresent(room) || !room.rematch.requestedBySlot[0] || !room.rematch.requestedBySlot[1]) {
+    if (
+      !this.areBothPlayersPresent(room) ||
+      !room.rematch.requestedBySlot[0] ||
+      !room.rematch.requestedBySlot[1]
+    ) {
       return { events };
     }
 
-    room.phase = 'starting';
+    room.phase = "starting";
     room.version += 1;
     room.match = createInitialMatchState(room.roomCode);
     room.countdown = null;
     room.teardownAt = null;
-    room.players.forEach((slot) => { slot.ready = false; });
+    room.players.forEach((slot) => {
+      slot.ready = false;
+    });
     this.clearRematchState(room);
 
     const now = Date.now();
-    room.countdown = { startedAt: now, endsAt: now + 3000, secondsRemaining: 3 };
+    room.countdown = {
+      startedAt: now,
+      endsAt: now + 3000,
+      secondsRemaining: 3,
+    };
     events.push(...this.buildLobbyStateEvents(room));
     events.push(...this.buildGameStateEvents(room, 3));
     events.push(...this.buildCountdownEvents(room, 3, now));
@@ -211,22 +256,35 @@ export class RoomService {
 
   setDirection(socketId: string, direction: Direction): ServiceResult {
     const room = this.getRoomForSocket(socketId);
-    if (!room || !room.match || (room.phase !== 'starting' && room.phase !== 'in-progress')) {
-      return { events: [this.error(socketId, 'ACTION_NOT_ALLOWED')] };
+    if (
+      !room ||
+      !room.match ||
+      (room.phase !== "starting" && room.phase !== "in-progress")
+    ) {
+      return { events: [this.error(socketId, "ACTION_NOT_ALLOWED")] };
     }
 
     const player = room.players.find((slot) => slot.socketId === socketId);
-    if (!player) return { events: [this.error(socketId, 'ACTION_NOT_ALLOWED')] };
+    if (!player)
+      return { events: [this.error(socketId, "ACTION_NOT_ALLOWED")] };
 
-    const queued = queueDirectionInput(room.match.snakes[player.slotIndex], direction);
-    return queued ? { events: [] } : { events: [this.error(socketId, 'ACTION_NOT_ALLOWED')] };
+    const queued = queueDirectionInput(
+      room.match.snakes[player.slotIndex],
+      direction,
+    );
+    return queued
+      ? { events: [] }
+      : { events: [this.error(socketId, "ACTION_NOT_ALLOWED")] };
   }
 
   disconnect(socketId: string): ServiceResult {
-    return this.leaveCurrentRoom(socketId, 'disconnected');
+    return this.leaveCurrentRoom(socketId, "disconnected");
   }
 
-  private leaveCurrentRoom(socketId: string, reason: 'left' | 'disconnected'): ServiceResult {
+  private leaveCurrentRoom(
+    socketId: string,
+    reason: "left" | "disconnected",
+  ): ServiceResult {
     const roomCode = this.socketToRoom.get(socketId);
     if (!roomCode) return { events: [] };
 
@@ -235,7 +293,9 @@ export class RoomService {
     this.socketToPlayer.delete(socketId);
     if (!room) return { events: [] };
 
-    const leavingPlayer = room.players.find((slot) => slot.socketId === socketId);
+    const leavingPlayer = room.players.find(
+      (slot) => slot.socketId === socketId,
+    );
     if (!leavingPlayer) return { events: [] };
 
     const slotIndex = leavingPlayer.slotIndex;
@@ -250,23 +310,31 @@ export class RoomService {
       return { events: [] };
     }
 
-    if (room.phase === 'starting' || room.phase === 'in-progress') {
-      const events = this.finishMatch(room, applyDisconnectResult(room.match!, slotIndex, Date.now()), reason === 'disconnected' ? 'player-disconnected' : 'round-complete');
+    if (room.phase === "starting" || room.phase === "in-progress") {
+      const events = this.finishMatch(
+        room,
+        applyDisconnectResult(room.match!, slotIndex, Date.now()),
+        reason === "disconnected" ? "player-disconnected" : "round-complete",
+      );
       return { events };
     }
 
     remainingPlayers[0].ready = false;
     this.clearRematchState(room);
     room.countdown = null;
-    if (room.phase === 'game-over') {
+    if (room.phase === "game-over") {
       room.match = null;
       room.teardownAt = null;
     }
     room.version += 1;
-    room.phase = 'waiting-for-players';
+    room.phase = "waiting-for-players";
 
     const events: ClientEvent[] = remainingPlayers.flatMap((slot) => [
-      { type: 'player:left', socketId: slot.socketId!, payload: { roomCode, slotIndex, reason } satisfies PlayerLeftPayload },
+      {
+        type: "player:left",
+        socketId: slot.socketId!,
+        payload: { roomCode, slotIndex, reason } satisfies PlayerLeftPayload,
+      },
     ]);
     events.push(...this.buildLobbyStateEvents(room));
     events.push(...this.buildRematchStateEvents(room));
@@ -277,13 +345,17 @@ export class RoomService {
     const events = this.buildLobbyStateEvents(room);
     if (!this.canStart(room)) return events;
 
-    room.phase = 'starting';
+    room.phase = "starting";
     room.version += 1;
     room.match = createInitialMatchState(room.roomCode);
     room.countdown = null;
     this.clearRematchState(room);
     const now = Date.now();
-    room.countdown = { startedAt: now, endsAt: now + 3000, secondsRemaining: 3 };
+    room.countdown = {
+      startedAt: now,
+      endsAt: now + 3000,
+      secondsRemaining: 3,
+    };
     events.push(...this.buildLobbyStateEvents(room));
     events.push(...this.buildGameStateEvents(room, 3));
     events.push(...this.buildCountdownEvents(room, 3, now));
@@ -295,28 +367,41 @@ export class RoomService {
 
   private startCountdown(roomCode: string) {
     this.cancelRuntime(roomCode);
-    const runtime: RuntimeRecord = { countdownTimers: [], tickTimer: null, teardownTimer: null };
+    const runtime: RuntimeRecord = {
+      countdownTimers: [],
+      tickTimer: null,
+      teardownTimer: null,
+    };
     const room = this.rooms.get(roomCode);
     if (!room || !room.countdown) return;
 
     ([2, 1, 0] as const).forEach((second, index) => {
-      const timer = setTimeout(() => {
-        const activeRoom = this.rooms.get(roomCode);
-        if (!activeRoom || activeRoom.phase !== 'starting' || !activeRoom.countdown || !activeRoom.match) return;
-        activeRoom.countdown.secondsRemaining = second;
-        activeRoom.version += 1;
-        const now = Date.now();
-        const events: ClientEvent[] = [
-          ...this.buildLobbyStateEvents(activeRoom),
-          ...this.buildGameStateEvents(activeRoom, second),
-          ...this.buildCountdownEvents(activeRoom, second, now),
-          ...this.buildRematchStateEvents(activeRoom),
-        ];
-        if (second === 0) {
-          events.push(...this.beginActiveMatch(activeRoom, now));
-        }
-        this.emitExternal(events);
-      }, (index + 1) * 1000);
+      const timer = setTimeout(
+        () => {
+          const activeRoom = this.rooms.get(roomCode);
+          if (
+            !activeRoom ||
+            activeRoom.phase !== "starting" ||
+            !activeRoom.countdown ||
+            !activeRoom.match
+          )
+            return;
+          activeRoom.countdown.secondsRemaining = second;
+          activeRoom.version += 1;
+          const now = Date.now();
+          const events: ClientEvent[] = [
+            ...this.buildLobbyStateEvents(activeRoom),
+            ...this.buildGameStateEvents(activeRoom, second),
+            ...this.buildCountdownEvents(activeRoom, second, now),
+            ...this.buildRematchStateEvents(activeRoom),
+          ];
+          if (second === 0) {
+            events.push(...this.beginActiveMatch(activeRoom, now));
+          }
+          this.emitExternal(events);
+        },
+        (index + 1) * 1000,
+      );
       runtime.countdownTimers.push(timer);
     });
 
@@ -325,18 +410,18 @@ export class RoomService {
 
   private beginActiveMatch(room: RoomRecord, now: number): ClientEvent[] {
     if (!room.match) return [];
-    room.phase = 'in-progress';
+    room.phase = "in-progress";
     room.version += 1;
     room.countdown = null;
-    room.match.status = 'active';
+    room.match.status = "active";
     room.match.startedAt = now;
     const payload: GameStartPayload = {
       roomCode: room.roomCode,
-      phase: 'in-progress',
+      phase: "in-progress",
       board: room.match.board,
       players: [
-        { slotIndex: 0, label: 'Player 1' },
-        { slotIndex: 1, label: 'Player 2' },
+        { slotIndex: 0, label: "Player 1" },
+        { slotIndex: 1, label: "Player 2" },
       ],
       tickIntervalMs: room.match.tickIntervalMs,
       startedAt: now,
@@ -344,7 +429,8 @@ export class RoomService {
     };
     const events = this.buildLobbyStateEvents(room);
     for (const player of room.players) {
-      if (player.socketId) events.push({ type: 'game:start', socketId: player.socketId, payload });
+      if (player.socketId)
+        events.push({ type: "game:start", socketId: player.socketId, payload });
     }
     this.scheduleNextTick(room.roomCode, room.match.tickIntervalMs);
     return events;
@@ -355,11 +441,11 @@ export class RoomService {
     if (!runtime) return;
     runtime.tickTimer = setTimeout(() => {
       const room = this.rooms.get(roomCode);
-      if (!room || room.phase !== 'in-progress' || !room.match) return;
+      if (!room || room.phase !== "in-progress" || !room.match) return;
       room.match = advanceOneTick(room.match, Date.now());
       room.version += 1;
       if (room.match.result) {
-        this.emitExternal(this.finishMatch(room, room.match, 'round-complete'));
+        this.emitExternal(this.finishMatch(room, room.match, "round-complete"));
         return;
       }
       this.emitExternal(this.buildGameStateEvents(room));
@@ -367,9 +453,13 @@ export class RoomService {
     }, delayMs);
   }
 
-  private finishMatch(room: RoomRecord, match: MatchState, closeReason: 'round-complete' | 'player-disconnected'): ClientEvent[] {
+  private finishMatch(
+    room: RoomRecord,
+    match: MatchState,
+    closeReason: "round-complete" | "player-disconnected",
+  ): ClientEvent[] {
     room.match = match;
-    room.phase = 'game-over';
+    room.phase = "game-over";
     room.version += 1;
     room.teardownAt = null;
     this.clearRematchState(room);
@@ -378,7 +468,7 @@ export class RoomService {
     const finalState = this.serializeGameState(room);
     const payload: GameEndedPayload = {
       roomCode: room.roomCode,
-      phase: 'game-over',
+      phase: "game-over",
       result: {
         bySlot: {
           0: toOutcomeForSlot(match, 0),
@@ -394,9 +484,17 @@ export class RoomService {
 
     const events = this.buildLobbyStateEvents(room);
     events.push(...this.buildGameStateEvents(room));
-    events.push(...this.buildRematchStateEvents(room, closeReason === 'player-disconnected' ? 'Opponent disconnected. Room stays open for another player.' : 'Round complete. Choose rematch to play again.'));
+    events.push(
+      ...this.buildRematchStateEvents(
+        room,
+        closeReason === "player-disconnected"
+          ? "Opponent disconnected. Room stays open for another player."
+          : "Round complete. Choose rematch to play again.",
+      ),
+    );
     for (const player of room.players) {
-      if (player.socketId) events.push({ type: 'game:ended', socketId: player.socketId, payload });
+      if (player.socketId)
+        events.push({ type: "game:ended", socketId: player.socketId, payload });
     }
 
     return events;
@@ -419,12 +517,21 @@ export class RoomService {
   private buildLobbyStateEvents(room: RoomRecord): ClientEvent[] {
     return room.players.flatMap((player) => {
       if (!player.socketId) return [];
-      return [{ type: 'lobby:state' as const, socketId: player.socketId, payload: this.serializeLobbyState(room, player.socketId) }];
+      return [
+        {
+          type: "lobby:state" as const,
+          socketId: player.socketId,
+          payload: this.serializeLobbyState(room, player.socketId),
+        },
+      ];
     });
   }
 
-  private buildRematchStateEvents(room: RoomRecord, message?: string): ClientEvent[] {
-    const phase = room.phase === 'in-progress' ? null : room.phase;
+  private buildRematchStateEvents(
+    room: RoomRecord,
+    message?: string,
+  ): ClientEvent[] {
+    const phase = room.phase === "in-progress" ? null : room.phase;
     if (!phase) return [];
     return room.players.flatMap((player) => {
       if (!player.socketId) return [];
@@ -435,33 +542,73 @@ export class RoomService {
         version: room.version,
         message,
       };
-      return [{ type: 'game:rematch-state' as const, socketId: player.socketId, payload }];
+      return [
+        {
+          type: "game:rematch-state" as const,
+          socketId: player.socketId,
+          payload,
+        },
+      ];
     });
   }
 
-  private buildCountdownEvents(room: RoomRecord, secondsRemaining: 3 | 2 | 1 | 0, now: number): ClientEvent[] {
+  private buildCountdownEvents(
+    room: RoomRecord,
+    secondsRemaining: 3 | 2 | 1 | 0,
+    now: number,
+  ): ClientEvent[] {
     if (!room.countdown) return [];
     const payload: GameCountdownPayload = {
       roomCode: room.roomCode,
-      phase: 'starting',
+      phase: "starting",
       secondsRemaining,
       startsAt: room.countdown.startedAt,
       serverNow: now,
       version: room.version,
     };
-    return room.players.flatMap((player) => (player.socketId ? [{ type: 'game:countdown' as const, socketId: player.socketId, payload }] : []));
+    return room.players.flatMap((player) =>
+      player.socketId
+        ? [
+            {
+              type: "game:countdown" as const,
+              socketId: player.socketId,
+              payload,
+            },
+          ]
+        : [],
+    );
   }
 
-  private buildGameStateEvents(room: RoomRecord, countdownSecondsRemaining?: 3 | 2 | 1 | 0): ClientEvent[] {
+  private buildGameStateEvents(
+    room: RoomRecord,
+    countdownSecondsRemaining?: 3 | 2 | 1 | 0,
+  ): ClientEvent[] {
     if (!room.match) return [];
-    const payload = this.serializeGameState(room, countdownSecondsRemaining);
-    return room.players.flatMap((player) => (player.socketId ? [{ type: 'game:state' as const, socketId: player.socketId, payload }] : []));
+    return room.players.flatMap((player) => {
+      if (!player.socketId) return [];
+      return [
+        {
+          type: "game:state" as const,
+          socketId: player.socketId,
+          payload: this.serializeGameState(
+            room,
+            player.socketId,
+            countdownSecondsRemaining,
+          ),
+        },
+      ];
+    });
   }
 
-  private serializeLobbyState(room: RoomRecord, viewerSocketId: string): LobbyStatePayload {
-    const occupiedCount = room.players.filter((player) => player.playerId).length as 0 | 1 | 2;
+  private serializeLobbyState(
+    room: RoomRecord,
+    viewerSocketId: string,
+  ): LobbyStatePayload {
+    const occupiedCount = room.players.filter((player) => player.playerId)
+      .length as 0 | 1 | 2;
     const allPlayersPresent = occupiedCount === 2;
-    const allReady = allPlayersPresent && room.players.every((player) => player.ready);
+    const allReady =
+      allPlayersPresent && room.players.every((player) => player.ready);
     const canStart = this.canStart(room);
 
     return {
@@ -471,9 +618,9 @@ export class RoomService {
         slotIndex: player.slotIndex,
         isOccupied: Boolean(player.playerId),
         isReady: Boolean(player.playerId) && player.ready,
-        label: player.slotIndex === 0 ? 'Player 1' : 'Player 2',
+        label: player.slotIndex === 0 ? "Player 1" : "Player 2",
         isYou: player.socketId === viewerSocketId,
-      })) as LobbyStatePayload['players'],
+      })) as LobbyStatePayload["players"],
       occupiedCount,
       allPlayersPresent,
       allReady,
@@ -484,11 +631,20 @@ export class RoomService {
     };
   }
 
-  private serializeGameState(room: RoomRecord, countdownSecondsRemaining?: 3 | 2 | 1 | 0): GameStatePayload {
+  private serializeGameState(
+    room: RoomRecord,
+    viewerSocketId?: string,
+    countdownSecondsRemaining?: 3 | 2 | 1 | 0,
+  ): GameStatePayload {
     const match = room.match!;
     return {
       roomCode: room.roomCode,
-      phase: room.phase === 'game-over' ? 'game-over' : room.phase === 'starting' ? 'starting' : 'in-progress',
+      phase:
+        room.phase === "game-over"
+          ? "game-over"
+          : room.phase === "starting"
+            ? "starting"
+            : "in-progress",
       tickNumber: match.tickNumber,
       board: match.board,
       food: match.food,
@@ -498,37 +654,57 @@ export class RoomService {
         direction: snake.direction,
         alive: snake.alive,
         score: snake.score,
-      })) as GameStatePayload['snakes'],
+      })) as GameStatePayload["snakes"],
       foodsEaten: match.foodsEaten,
       tickIntervalMs: match.tickIntervalMs,
       countdownSecondsRemaining,
-      result: room.phase === 'game-over'
-        ? {
-            outcome: match.result === 'draw' ? 'draw' : match.winnerSlotIndex === 0 ? 'win' : 'lose',
-            winnerSlotIndex: match.winnerSlotIndex,
-            deathReasons: match.deathReasons,
-          }
-        : undefined,
-      rematch: this.buildRematchView(room),
+      result:
+        room.phase === "game-over"
+          ? {
+              outcome:
+                match.result === "draw"
+                  ? "draw"
+                  : match.winnerSlotIndex === 0
+                    ? "win"
+                    : "lose",
+              winnerSlotIndex: match.winnerSlotIndex,
+              deathReasons: match.deathReasons,
+            }
+          : undefined,
+      rematch: this.buildRematchView(room, viewerSocketId),
       version: room.version,
     };
   }
 
-  private buildRematchView(room: RoomRecord, viewerSocketId?: string): RematchView {
-    const eligiblePlayerCount = room.players.filter((player) => player.playerId && player.connected).length as 0 | 1 | 2;
-    const bothAccepted = eligiblePlayerCount === 2 && room.rematch.requestedBySlot[0] && room.rematch.requestedBySlot[1];
-    const acceptedCount = Number(room.rematch.requestedBySlot[0]) + Number(room.rematch.requestedBySlot[1]);
-    const available = room.phase === 'game-over' && eligiblePlayerCount === 2;
-    const viewer = viewerSocketId ? room.players.find((slot) => slot.socketId === viewerSocketId) : null;
-    const requestedByYou = viewer ? room.rematch.requestedBySlot[viewer.slotIndex] : false;
+  private buildRematchView(
+    room: RoomRecord,
+    viewerSocketId?: string,
+  ): RematchView {
+    const eligiblePlayerCount = room.players.filter(
+      (player) => player.playerId && player.connected,
+    ).length as 0 | 1 | 2;
+    const bothAccepted =
+      eligiblePlayerCount === 2 &&
+      room.rematch.requestedBySlot[0] &&
+      room.rematch.requestedBySlot[1];
+    const acceptedCount =
+      Number(room.rematch.requestedBySlot[0]) +
+      Number(room.rematch.requestedBySlot[1]);
+    const available = room.phase === "game-over" && eligiblePlayerCount === 2;
+    const viewer = viewerSocketId
+      ? room.players.find((slot) => slot.socketId === viewerSocketId)
+      : null;
+    const requestedByYou = viewer
+      ? room.rematch.requestedBySlot[viewer.slotIndex]
+      : false;
     const waitingForOtherPlayer = available && requestedByYou && !bothAccepted;
     const status = !available
-      ? 'unavailable'
+      ? "unavailable"
       : bothAccepted
-        ? 'accepted'
+        ? "accepted"
         : acceptedCount === 1
-          ? 'waiting'
-          : 'idle';
+          ? "waiting"
+          : "idle";
 
     return {
       available,
@@ -542,26 +718,39 @@ export class RoomService {
   }
 
   private getLobbyMessage(room: RoomRecord): string {
-    if (room.phase === 'starting' && room.countdown) return `Match starts in ${room.countdown.secondsRemaining}…`;
-    if (room.phase === 'in-progress') return 'Match in progress.';
-    if (room.phase === 'game-over') return this.buildRematchView(room).available ? 'Round complete. Choose rematch to play again.' : 'Round complete. Waiting for opponent status to change.';
+    if (room.phase === "starting" && room.countdown)
+      return `Match starts in ${room.countdown.secondsRemaining}…`;
+    if (room.phase === "in-progress") return "Match in progress.";
+    if (room.phase === "game-over")
+      return this.buildRematchView(room).available
+        ? "Round complete. Choose rematch to play again."
+        : "Round complete. Waiting for opponent status to change.";
     return room.players.filter((player) => player.playerId).length === 2
-      ? 'Game starts automatically when both players are ready.'
-      : 'Waiting for opponent.';
+      ? "Game starts automatically when both players are ready."
+      : "Waiting for opponent.";
   }
 
   private canStart(room: RoomRecord): boolean {
-    return !room.match && room.players.every((player) => player.playerId && player.connected && player.ready);
+    return (
+      !room.match &&
+      room.players.every(
+        (player) => player.playerId && player.connected && player.ready,
+      )
+    );
   }
 
   private computePhase(room: RoomRecord): RoomPhase {
-    const occupiedCount = room.players.filter((player) => player.playerId).length;
-    if (occupiedCount < 2) return 'waiting-for-players';
-    return 'lobby';
+    const occupiedCount = room.players.filter(
+      (player) => player.playerId,
+    ).length;
+    if (occupiedCount < 2) return "waiting-for-players";
+    return "lobby";
   }
 
   private areBothPlayersPresent(room: RoomRecord): boolean {
-    return room.players.every((player) => player.playerId && player.connected && player.socketId);
+    return room.players.every(
+      (player) => player.playerId && player.connected && player.socketId,
+    );
   }
 
   private clearRematchState(room: RoomRecord) {
@@ -587,23 +776,30 @@ export class RoomService {
   }
 
   private generateUniqueRoomCode(): string {
-    const letters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
-    let code = '';
+    const letters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+    let code = "";
     do {
-      code = Array.from({ length: 4 }, () => letters[Math.floor(Math.random() * letters.length)]).join('');
+      code = Array.from(
+        { length: 4 },
+        () => letters[Math.floor(Math.random() * letters.length)],
+      ).join("");
     } while (this.rooms.has(code));
     return code;
   }
 
   private error(socketId: string, reason: LobbyErrorReason): ClientEvent {
     const messages: Record<LobbyErrorReason, string> = {
-      INVALID_ROOM_CODE: 'Enter a valid room code.',
-      ROOM_NOT_FOUND: 'Room no longer exists.',
-      ROOM_FULL: 'That room is already full.',
-      GAME_ALREADY_STARTED: 'That game has already started.',
-      ACTION_NOT_ALLOWED: 'That action is not available right now.',
+      INVALID_ROOM_CODE: "Enter a valid room code.",
+      ROOM_NOT_FOUND: "Room no longer exists.",
+      ROOM_FULL: "That room is already full.",
+      GAME_ALREADY_STARTED: "That game has already started.",
+      ACTION_NOT_ALLOWED: "That action is not available right now.",
     };
 
-    return { type: 'room:error', socketId, payload: { reason, message: messages[reason] } };
+    return {
+      type: "room:error",
+      socketId,
+      payload: { reason, message: messages[reason] },
+    };
   }
 }

--- a/src/shared/contracts.ts
+++ b/src/shared/contracts.ts
@@ -2,6 +2,7 @@ export type RoomPhase = 'waiting-for-players' | 'lobby' | 'starting' | 'in-progr
 export type Direction = 'up' | 'down' | 'left' | 'right';
 export type RoundResult = 'win' | 'lose' | 'draw';
 export type DeathReason = 'wall' | 'self' | 'head-to-head' | 'head-to-body' | 'cross-over' | 'disconnect';
+export type RematchStatus = 'unavailable' | 'idle' | 'waiting' | 'accepted';
 
 export type LobbyErrorReason =
   | 'INVALID_ROOM_CODE'
@@ -13,6 +14,16 @@ export type LobbyErrorReason =
 export interface GridPoint {
   x: number;
   y: number;
+}
+
+export interface RematchView {
+  available: boolean;
+  status: RematchStatus;
+  requestedBySlot: { 0: boolean; 1: boolean };
+  requestedByYou: boolean;
+  waitingForOtherPlayer: boolean;
+  bothAccepted: boolean;
+  eligiblePlayerCount: 0 | 1 | 2;
 }
 
 export interface LobbyPlayerView {
@@ -33,6 +44,7 @@ export interface LobbyStatePayload {
   canStart: boolean;
   version: number;
   message?: string;
+  rematch: RematchView;
 }
 
 export interface PublicSnakeState {
@@ -61,6 +73,7 @@ export interface PublicGameStatePayload {
     winnerSlotIndex: 0 | 1 | null;
     deathReasons: Array<{ slotIndex: 0 | 1; reason: DeathReason }>;
   };
+  rematch: RematchView;
   version: number;
 }
 
@@ -128,8 +141,16 @@ export interface GameEndedPayload {
     deathReasons: Array<{ slotIndex: 0 | 1; reason: DeathReason }>;
   };
   finalState: PublicGameStatePayload;
-  teardownAt: number;
+  teardownAt: number | null;
   version: number;
+}
+
+export interface GameRematchStatePayload {
+  roomCode: string;
+  phase: 'game-over' | 'waiting-for-players' | 'lobby' | 'starting';
+  rematch: RematchView;
+  version: number;
+  message?: string;
 }
 
 export interface RoomClosedPayload {
@@ -152,5 +173,7 @@ export const EVENTS = {
   gameStart: 'game:start',
   gameState: 'game:state',
   gameEnded: 'game:ended',
+  gameRematchRequest: 'game:rematch-request',
+  gameRematchState: 'game:rematch-state',
   roomClosed: 'room:closed',
 } as const;


### PR DESCRIPTION
Implements replay / rematch flow for issue #13.

## What changed
- keep rooms open after game over and model rematch as server-authoritative sub-state
- add rematch request/state socket events and same-room fresh countdown restart
- clear stale rematch state on post-game leave/disconnect and allow replacement join
- add rematch UI and coverage for required replay scenarios

## Checks
- npm test
- npm run build