### PR TITLE
Issue #63: Disconnect / reconnect handling

### DIFF
--- a/docs/impl/disconnect-reconnect-handling/api-contracts.md
+++ b/docs/impl/disconnect-reconnect-handling/api-contracts.md
@@ -1,0 +1,297 @@
+# Disconnect / reconnect handling API contracts
+
+## Contract goals
+These contracts extend the current Socket.IO room/game protocol with a lightweight same-browser reconnect path. They are intentionally room-scoped and in-memory.
+
+Design requirements:
+- no account system
+- same browser/device reclaim only
+- server-authoritative slot reclaim
+- explicit reconnect state visible to both players
+
+## New concepts
+
+### Session token
+Opaque reconnect secret minted by the server when a player first occupies a slot.
+
+### Reserved slot
+A slot whose player disconnected but whose ownership has not yet expired.
+
+### Reconnect window
+30-second server-owned timeout during which the reserved slot remains non-joinable by others.
+
+## New / extended shared types
+
+```ts
+export interface PlayerSessionPayload {
+  roomCode: string;
+  slotIndex: 0 | 1;
+  reconnectToken: string;
+  issuedAt: number;
+  version: number;
+}
+
+export interface SessionResumeRequestPayload {
+  roomCode: string;
+  reconnectToken: string;
+}
+
+export interface SessionResumeSucceededPayload {
+  roomCode: string;
+  slotIndex: 0 | 1;
+  phase: RoomPhase;
+  resumedAt: number;
+  version: number;
+}
+
+export interface SessionResumeFailedPayload {
+  roomCode: string;
+  reason:
+    | 'ROOM_NOT_FOUND'
+    | 'RESERVATION_EXPIRED'
+    | 'TOKEN_MISMATCH'
+    | 'SLOT_NOT_RESERVED'
+    | 'SLOT_ALREADY_ACTIVE';
+  message: string;
+}
+```
+
+### Reconnect view embedded in authoritative payloads
+```ts
+export type ReconnectStatus = 'none' | 'waiting-for-player' | 'resume-countdown';
+
+export interface ReconnectView {
+  active: boolean;
+  status: ReconnectStatus;
+  disconnectedSlotIndex: 0 | 1 | null;
+  reservedUntil: number | null;
+  secondsRemaining: number | null;
+  affectedPhase: 'waiting-for-players' | 'lobby' | 'starting' | 'in-progress' | 'game-over' | null;
+  yourSlotReserved: boolean;
+  canAutoResume: boolean;
+}
+```
+
+### Lobby player visibility
+Current lobby slot shape should expose reservation state explicitly:
+
+```ts
+export interface LobbyPlayerView {
+  slotIndex: 0 | 1;
+  isOccupied: boolean;
+  isReady: boolean;
+  isConnected: boolean;
+  isReserved: boolean;
+  label: 'Player 1' | 'Player 2';
+  isYou: boolean;
+}
+```
+
+## Extended payloads
+
+### `lobby:state`
+Add:
+- `players[n].isConnected`
+- `players[n].isReserved`
+- `reconnect: ReconnectView`
+
+Semantics:
+- `isOccupied=true` + `isConnected=false` + `isReserved=true` means the slot is held for reconnect
+- room remains non-joinable for that slot until reservation expires
+
+### `game:state`
+Add:
+- `reconnect: ReconnectView`
+- optional `paused: boolean`
+
+Semantics:
+- during reconnect wait, `phase` may stay `starting` or `in-progress`
+- `paused=true` means authoritative progression is frozen
+
+### `game:rematch-state`
+Add / reuse:
+- `reconnect: ReconnectView`
+
+Semantics:
+- rematch state must reflect that one player is temporarily disconnected but still eligible to return during reservation window
+
+## New client -> server events
+
+### `session:resume`
+Attempt to reclaim a reserved slot.
+
+```ts
+socket.emit('session:resume', {
+  roomCode: 'ABCD',
+  reconnectToken: '<opaque-token>',
+} satisfies SessionResumeRequestPayload)
+```
+
+Validation rules:
+- room exists
+- one slot in room matches token
+- slot is reserved and disconnected
+- reservation has not expired
+- slot is not already rebound to another live socket
+
+Side effects on success:
+- bind new `socketId` to slot
+- mark player connected
+- clear reconnect timeout runtime
+- cancel or resolve paused reconnect state
+- emit full authoritative room/game snapshot
+
+## New server -> client events
+
+### `session:issued`
+Sent to the player that just occupied a slot.
+
+```ts
+{
+  roomCode: 'ABCD',
+  slotIndex: 0,
+  reconnectToken: '<opaque-token>',
+  issuedAt: 1770000000000,
+  version: 4,
+}
+```
+
+Client behavior:
+- store in local storage immediately
+- overwrite any prior token for same room/slot context
+
+### `session:resume:succeeded`
+Sent to reconnecting socket after successful reclaim.
+
+```ts
+{
+  roomCode: 'ABCD',
+  slotIndex: 0,
+  phase: 'in-progress',
+  resumedAt: 1770000001234,
+  version: 21,
+}
+```
+
+Client behavior:
+- stay in room
+- await authoritative `lobby:state` / `game:state` / `game:rematch-state`
+- no manual confirmation needed
+
+### `session:resume:failed`
+Sent when reclaim is denied.
+
+```ts
+{
+  roomCode: 'ABCD',
+  reason: 'RESERVATION_EXPIRED',
+  message: 'Reconnect window expired. That slot is no longer reserved.',
+}
+```
+
+Client behavior:
+- clear stale local token for that room
+- return to ordinary create/join flow
+
+## Event sequencing
+
+### Fresh create
+1. client -> `room:create`
+2. server -> `room:created`
+3. server -> `session:issued`
+4. server -> `lobby:state`
+
+### Fresh join
+1. client -> `room:join`
+2. server -> `room:joined`
+3. server -> `session:issued`
+4. server -> `lobby:state` to both players
+
+### Disconnect during lobby
+1. transport disconnect detected
+2. server marks slot reserved for 30s
+3. server -> `lobby:state` to remaining player
+4. server -> optional `game:rematch-state` if room is post-game
+
+### Resume success during gameplay
+1. reconnecting client transport reconnects
+2. client -> `session:resume`
+3. server validates token and reservation
+4. server -> `session:resume:succeeded`
+5. server -> updated `lobby:state` / `game:state` to both players
+6. server -> resume countdown event(s) if using visible resume countdown
+7. server resumes active tick loop after countdown
+
+### Resume failure
+1. client -> `session:resume`
+2. server -> `session:resume:failed`
+3. client clears stored token and falls back to entry flow
+
+## Resume-countdown contract
+Recommended: reuse existing `game:countdown` event for resume countdown instead of inventing a second countdown transport.
+
+Contract rule:
+- `game:countdown` during reconnect resume still means authoritative movement has not started/resumed yet
+- clients should read `reconnect.status === 'resume-countdown'` to render copy like “Player reconnected. Resuming in 3…”
+
+This avoids creating parallel timer primitives.
+
+## Error semantics
+
+### Join attempts against reserved slot
+If room has one live player and one reserved slot, ordinary `room:join` should behave as:
+- if no open slot exists => `ROOM_FULL`
+
+This is important: reserved means unavailable to replacement joiners.
+
+### Direction / ready while reconnect wait is active
+- `player:direction:set` should be rejected while game is paused for reconnect
+- `player:ready:set` should be rejected while slot reservation prevents normal lobby readiness
+
+Use existing `ACTION_NOT_ALLOWED` unless the dev agent wants a more specific reason.
+
+## Versioning rules
+Every reconnect-related state change should increment room version:
+- slot reserved
+- reservation refreshed
+- reservation expired and slot reopened
+- resume succeeded
+- pause entered
+- resume countdown started/advanced/completed
+
+The same `version` discipline used elsewhere should continue so the client can treat reconnect transitions as ordinary authoritative updates.
+
+## Persistence rules
+- reconnect tokens live only in server memory and browser local storage
+- server restart invalidates all outstanding tokens
+- client must tolerate resume failure after server restart
+
+## Security / integrity notes
+This is deliberately not full auth, but the contracts should still follow these rules:
+- token must be opaque and high entropy
+- token should never be derivable from room code or slot index
+- token should rotate when slot ownership changes
+- token should only restore the exact reserved slot it was issued for
+- possession of token does not bypass room phase or expiry validation
+
+## Minimum test coverage expected from implementation
+1. `session:issued` emitted on create and join
+2. `session:resume` succeeds only for matching reserved slot
+3. invalid token fails with `session:resume:failed`
+4. expired reservation fails with `session:resume:failed`
+5. reserved slot blocks replacement `room:join`
+6. `lobby:state` exposes reserved/disconnected status correctly
+7. `game:state` exposes paused reconnect state correctly
+8. `game:countdown` reuse for resume works without double-starting gameplay
+9. timeout expiry transitions reserved slot back to open state
+10. gameplay timeout still emits correct `game:ended` winner/death reason
+
+## Guidance for the dev agent
+Prefer **small extensions to existing event families** over inventing a large new subsystem. The most important additions are:
+- `session:issued`
+- `session:resume`
+- `session:resume:succeeded`
+- `session:resume:failed`
+- embedded `reconnect` view on authoritative room/game payloads
+
+Keep the client dumb: it stores token, requests resume, and renders whatever the server says.

--- a/docs/impl/disconnect-reconnect-handling/deploy-log.md
+++ b/docs/impl/disconnect-reconnect-handling/deploy-log.md
@@ -1,0 +1,55 @@
+# Dev deployment log — Disconnect / reconnect handling
+
+## Deployment target
+- Parent issue: `#63`
+- PR: `#66`
+- Branch: `feature/issue-63`
+- Dev URL: `http://20.106.185.110:8081/`
+- Runtime: `pm2` process `app-dev` behind nginx on port `8081`, forwarding to local app on port `3001`
+- Deployed commit: `ac8ab14017da1cc69d187fa9e198a7d46a79c8ff` (`ac8ab14`)
+- Deployed at (UTC): `2026-03-12T17:35:08Z`
+
+## Deployment actions
+```bash
+cd /home/rootagent/deployments/dev
+git fetch origin
+git checkout -B feature/issue-63 origin/feature/issue-63
+git reset --hard origin/feature/issue-63
+npm ci
+npm run build
+pm2 startOrRestart /home/rootagent/deployments/ecosystem.config.js --only app-dev
+pm2 save
+```
+
+## Verification
+- `curl -I http://20.106.185.110:8081/` returned `HTTP/1.1 200 OK`.
+- `curl http://20.106.185.110:8081/build-info.json` returned `{"version":"0.1.0","commit":"ac8ab14","builtAt":"2026-03-12T17:35:08.005Z","displayVersion":"v0.1.0+ac8ab14"}`.
+- Served HTML contains visible build marker placeholders:
+  - `<div id="buildMarker" class="build-marker" ...>Build: loading…</div>`
+  - `<span id="gameBuildMarker" class="inline-build-marker" ...>Build: loading…</span>`
+- Served `app.js` includes the reconnect/resume flow and build marker hydration, including:
+  - `Connected. Trying to resume your room…`
+  - `session:resume:succeeded`
+  - `session:resume:failed`
+  - `Player X disconnected. Slot reserved for Ns.`
+  - `Player X reconnected. Resuming in Ns.`
+  - `/build-info.json` fetch with `cache: 'no-store'`
+- `pm2 list` showed `app-dev` online after restart.
+- `pm2 logs app-dev --lines 20 --nostream` showed the current startup line: `Room lobby server listening on http://localhost:3001 (v0.1.0+ac8ab14)`.
+
+## Notes
+- The feature did not previously have a `docs/impl/disconnect-reconnect-handling/deploy-log.md`, so this log was created as part of the dev deployment handoff.
+- Historical `app-dev` log noise includes older startup failures from earlier deployments, but the active process is healthy and the live build marker matches `ac8ab14`.
+
+## Deployment record
+
+| Field | Value |
+|---|---|
+| Commit | `ac8ab14017da1cc69d187fa9e198a7d46a79c8ff` |
+| Short | `ac8ab14` |
+| Branch | `feature/issue-63` |
+| Environment | `dev` |
+| PM2 Process | `app-dev` |
+| URL | `http://20.106.185.110:8081/` |
+| Timestamp | `2026-03-12T17:35:08Z` |
+| Status | `SUCCESS` |

--- a/docs/impl/disconnect-reconnect-handling/design.md
+++ b/docs/impl/disconnect-reconnect-handling/design.md
@@ -1,0 +1,486 @@
+# Disconnect / reconnect handling design
+
+## Overview
+This feature upgrades the current single-process Socket.IO room service from a **socket-bound occupancy model** to a **server-authoritative slot reservation model**. Today, a disconnect removes the player from the room immediately; during gameplay it ends the round right away, and outside gameplay it reopens the slot immediately. For issue #63, the room should instead preserve a disconnected player's identity and slot for **30 seconds** when the disconnect can be proven to come from the same browser/device.
+
+The core design choice is:
+
+- keep the server authoritative for slot ownership, timers, room lifecycle, and match outcomes
+- add a lightweight **local reconnect token** per occupied slot
+- treat disconnect as a **reservation state**, not immediate removal
+- allow only a reconnecting client with the matching local token to reclaim that reserved slot
+- reopen the slot only when the reservation expires or the room becomes irrelevant
+
+This stays aligned with MVP constraints:
+
+- no user accounts
+- no cross-device identity guarantees
+- single backend instance with in-memory room state
+- Socket.IO remains the primary transport
+
+## Goals
+1. Preserve a player's slot for 30 seconds after disconnect in lobby, countdown, gameplay, and post-game/rematch states.
+2. Allow automatic reclaim from the same browser/device using a local session token.
+3. Pause countdown/gameplay when reconnect is pending, then resume cleanly if reclaim succeeds.
+4. If reconnect times out during gameplay, award the remaining player the win.
+5. If reconnect times out during lobby or post-game/rematch, reopen the slot instead of killing the room.
+6. Keep the implementation server-authoritative without introducing full authentication.
+
+## Non-goals
+- account login or persistent identity across devices
+- reconnect after backend restart
+- reconnect across different browsers/devices
+- long-lived session storage in a database
+- spectator or observer support
+
+## Current architecture constraints
+Current `RoomService` state is keyed by room code and binds players directly to `socketId`. That creates three problems for reconnect support:
+
+1. **Identity is transient**: the reconnecting browser gets a new socket id, so the server cannot tell whether it is the same player.
+2. **Disconnect is destructive**: `leaveCurrentRoom()` clears `playerId`, `socketId`, and readiness immediately.
+3. **Gameplay disconnect is terminal**: `starting` / `in-progress` disconnect currently resolves the round immediately.
+
+The reconnect design should preserve the existing room/match structure but change the player-slot lifecycle.
+
+## Proposed model
+
+### 1. Separate player identity from connection identity
+A player slot should no longer be defined by `socketId`. Instead, it should be defined by a stable in-room session identity:
+
+- `playerId`: server-owned logical player identity inside the room
+- `reconnectToken`: opaque secret minted by the server and stored only in the same browser/device
+- `socketId`: current live transport binding, nullable while disconnected
+
+That yields this rule:
+
+- **slot ownership belongs to `playerId` + reconnect token**
+- **socket binding is replaceable**
+
+### 2. Add reservation state to player slots
+Extend each slot to distinguish these states:
+
+- `open`: no player owns the slot
+- `occupied-connected`: player owns slot and has a live socket
+- `occupied-reserved`: player owns slot, socket is gone, reconnect window is active
+
+Recommended shape:
+
+```ts
+interface PlayerSlot {
+  slotIndex: 0 | 1;
+  playerId: string | null;
+  socketId: string | null;
+  connected: boolean;
+  ready: boolean;
+  reconnectToken: string | null;
+  disconnectedAt: number | null;
+  reservationExpiresAt: number | null;
+}
+```
+
+### 3. Add room-level reconnect runtime state
+The room must know whether reconnect is pending and whether gameplay/countdown is paused because of it.
+
+```ts
+interface DisconnectWindow {
+  slotIndex: 0 | 1;
+  startedAt: number;
+  expiresAt: number;
+  reason: 'socket-disconnect';
+  affectedPhase: 'waiting-for-players' | 'lobby' | 'starting' | 'in-progress' | 'game-over';
+}
+
+interface PausedMatchState {
+  pausedAt: number;
+  pauseReason: 'player-disconnected';
+  disconnectedSlotIndex: 0 | 1;
+  resumeCountdownRemainingMs?: number;
+  resumeTickDelayMs?: number;
+}
+```
+
+Recommended `RoomRecord` additions:
+
+- `disconnectWindow: DisconnectWindow | null`
+- `pausedMatch: PausedMatchState | null`
+- dedicated reconnect timeout timer handle in runtime
+
+Only one disconnect window should be active at a time for MVP because the room supports only two players and any second disconnect while already waiting should collapse into ordinary room cleanup / round resolution rules.
+
+## Local session token strategy
+
+### Token lifecycle
+On successful room create or successful room join, the server should mint a cryptographically random opaque token, for example 128+ bits base64url.
+
+The token is:
+- unique per slot occupancy
+- scoped to one room slot ownership period
+- rotated whenever a new player newly takes a slot
+- cleared when the slot fully reopens
+
+The browser stores the token in local storage under room-scoped keying, for example:
+
+```ts
+localStorage['snake:session:<roomCode>'] = JSON.stringify({
+  roomCode,
+  playerToken,
+  slotIndex,
+  playerLabel,
+  lastKnownVersion,
+});
+```
+
+### Why this is enough for MVP
+This is not strong authentication. It is only a proof that the reconnecting browser still holds the locally issued secret from the earlier session. That is exactly the accepted scope: same browser/device reclaim only.
+
+### Server-authoritative rule
+The client presenting a token is only a *claim*. The server decides whether reclaim is valid by verifying all of:
+
+1. room exists
+2. slot is currently reserved, not open
+3. reconnect window has not expired
+4. presented token matches the slot's stored reconnect token
+5. no other socket is already actively bound to that slot
+
+If any check fails, the reclaim is denied and the browser falls back to ordinary create/join flow.
+
+## Connection and reclaim flow
+
+### Fresh create/join
+1. Client connects normally.
+2. Client emits `room:create` or `room:join`.
+3. Server allocates slot and mints reconnect token.
+4. Server returns normal room payload plus a new `session` payload containing token metadata.
+5. Client stores token locally.
+
+### Automatic reconnect after refresh / transient disconnect
+1. Browser reconnects with a fresh socket.
+2. Client checks local storage for last room session.
+3. If found, client emits `session:resume` immediately after socket connect.
+4. Server validates token against reserved slot.
+5. On success, server rebinds the new socket to the existing slot and broadcasts updated state.
+6. Client automatically returns to lobby/game/rematch context with no manual confirmation step.
+
+### Failed resume
+If resume fails because room is gone, slot reopened, or token mismatches:
+- server emits `session:resume:failed`
+- client clears local stored token for that room
+- UI returns to ordinary entry/create/join state
+
+## Disconnect handling rules by phase
+
+### A. Waiting-for-players / lobby
+When a player disconnects before gameplay is active:
+
+1. do **not** clear `playerId` or `reconnectToken`
+2. set `connected = false`, `socketId = null`
+3. set `reservationExpiresAt = now + 30_000`
+4. clear `ready` for the disconnected slot
+5. clear ready for the remaining player if needed so restart requires explicit readiness after state changes
+6. keep room open
+7. broadcast updated lobby state showing slot as reserved/disconnected
+
+If reconnect succeeds within 30 seconds:
+- rebind socket
+- restore slot ownership unchanged
+- room returns to `lobby`
+- players may ready again / continue where appropriate
+
+If timeout expires:
+- fully clear that slot
+- room returns to ordinary `waiting-for-players`
+- replacement player may join
+
+### B. Countdown (`starting`)
+A refresh during countdown should not immediately cost the round.
+
+On disconnect during `starting`:
+1. freeze countdown progression
+2. record remaining time until next countdown step / active start
+3. mark slot reserved for 30 seconds
+4. broadcast reconnect-waiting state to both sides
+
+If reconnect succeeds in time:
+- rebind slot
+- resume countdown from the same remaining time, not from a brand-new 3 seconds
+- rebroadcast authoritative countdown state
+
+If timeout expires:
+- remaining connected player wins by disconnect
+- room transitions through `game-over`
+- because issue #63 says gameplay timeout loss applies during active gameplay, countdown should follow the same pre-round fairness rule and be treated as gameplay-adjacent start state
+
+Implementation note: this is the one ambiguous point versus the spec wording. To keep behavior consistent and simpler for the dev agent, treat `starting` the same as active match handling: paused reconnect window, then win by forfeit on expiry.
+
+### C. Active gameplay (`in-progress`)
+On disconnect during active play:
+1. stop the active tick timer
+2. store pause metadata so resume can continue without corrupting cadence
+3. mark disconnected slot reserved for 30 seconds
+4. keep board/match state frozen exactly as last authoritative snapshot
+5. broadcast pause + reconnect countdown state to both players
+
+If reconnect succeeds in time:
+- bind new socket to same slot
+- send latest frozen game snapshot to both clients
+- resume tick loop after a short server-controlled resume countdown (recommended: 3 seconds) or resume immediately if implementation wants to minimize scope
+
+Recommendation: use a **short resume countdown** because it makes the pause feel intentional and fair. This countdown should be server-authored and visible to both players.
+
+If timeout expires:
+- disconnected player loses by `disconnect`
+- remaining player wins
+- room transitions to `game-over`
+- room remains open afterward for rematch/replacement behavior already established by issue # replay/rematch work
+
+### D. Post-game / rematch (`game-over`)
+When a player disconnects while the room is showing result/rematch state:
+
+1. keep their slot reserved for 30 seconds
+2. clear any rematch acceptance tied to the now-disconnected player
+3. keep room open for the remaining player
+4. show reconnect-waiting / reserved-slot messaging
+
+If reconnect succeeds in time:
+- player returns to same slot
+- rematch state remains reset (safer, simpler, avoids stale one-click rematch ambiguity)
+- both players can request rematch again
+
+If timeout expires:
+- slot reopens
+- room returns to `waiting-for-players`
+- a replacement player may join using the same room code
+
+This aligns reconnect timeout semantics with existing reopen behavior introduced in the replay/rematch feature.
+
+## Pause / resume semantics
+
+### Principle
+The server freezes authoritative progression; the client never free-runs or predicts through the disconnect window.
+
+### Countdown freeze
+For `starting`, store:
+- `countdown.secondsRemaining`
+- exact milliseconds until the next step
+
+Resume behavior:
+- either continue exact remaining ms to next tick, then continue normal 1-second countdown cadence
+- or normalize to a fresh short resume countdown owned by the server
+
+Preferred implementation: **fresh resume countdown for both countdown and active gameplay**.
+
+Why:
+- easier to reason about than restoring fractional countdown timers
+- clearer in UI
+- avoids edge cases around reconnecting at `secondsRemaining = 0`
+
+Recommended behavior:
+- if reconnect resumes a paused `starting` state, restart a 3-second authoritative countdown from current board state
+- no movement occurs until it completes
+
+This slightly favors clarity over exact timer continuity and still satisfies the product requirement because the match was paused intentionally.
+
+### Gameplay freeze
+For `in-progress`, store the frozen match snapshot and stop the tick loop.
+
+On successful reclaim:
+- keep scores, positions, food, speed, queued directions exactly as frozen
+- clear any queued directions from the disconnected player's prior socket if they were transport artifacts
+- run a short 3-second resume countdown
+- resume ticks only after countdown ends
+
+This prevents immediate surprise collisions on re-entry.
+
+## Lobby and rematch reopen behavior
+
+### Reservation timeout expiry outside gameplay
+When timeout expires in `waiting-for-players`, `lobby`, or `game-over`:
+- fully clear the reserved slot
+- keep room code alive
+- keep remaining player in room
+- reset readiness / rematch acceptance as needed
+- broadcast updated open-slot state
+
+### Remaining player leaves while waiting
+If the remaining connected player also leaves during a disconnect window:
+- room should be disposed
+- no need to preserve a one-player reservation in an empty room
+
+### Replacement player join rules
+A replacement player can join only if:
+- slot is open, not reserved
+- room phase is not `starting` or `in-progress`
+- or room is `game-over` with an open slot and no active disconnect reservation
+
+A reserved slot is **not joinable** even if the socket is absent.
+
+## State machine changes
+
+### Slot state transitions
+```text
+open
+  -> occupied-connected         (create/join)
+occupied-connected
+  -> occupied-reserved          (socket disconnect)
+occupied-reserved
+  -> occupied-connected         (session resume success)
+occupied-reserved
+  -> open                       (timeout expiry)
+occupied-connected
+  -> open                       (voluntary leave semantics if we keep leave destructive)
+```
+
+### Room behavior summary
+- `waiting-for-players` / `lobby`: disconnect reserves slot, timeout reopens slot
+- `starting`: disconnect pauses start, timeout awards win to remaining player
+- `in-progress`: disconnect pauses game, timeout awards win to remaining player
+- `game-over`: disconnect reserves slot, timeout reopens slot and keeps room reusable
+
+## Server changes by subsystem
+
+### 1. Room service
+Refactor `RoomService` so slot clearing is no longer the first response to disconnect.
+
+Introduce methods conceptually like:
+- `reserveDisconnectedSlot(room, slotIndex, phase)`
+- `resumeReservedSlot(socketId, roomCode, reconnectToken)`
+- `expireDisconnectedSlot(roomCode, slotIndex)`
+- `pauseCountdownForReconnect(room, slotIndex)`
+- `pauseMatchForReconnect(room, slotIndex)`
+- `resumePausedRound(room)`
+
+Important: `leave` and `disconnect` should diverge.
+- **disconnect** => reserve when eligible
+- **explicit leave** => may still clear immediately if product wants that behavior
+
+For MVP simplicity, browser tab close / refresh will appear as disconnect; explicit leave button does not currently exist, so most real exits will use reservation rules.
+
+### 2. Runtime timers
+Current runtime already has countdown/tick timers. Add:
+- reconnect expiration timer
+- optional resume countdown timer
+
+When entering reconnect-waiting:
+- cancel tick/countdown timers
+- start reconnect expiration timer
+
+When reconnect succeeds:
+- cancel expiration timer
+- start resume countdown timer or restore paused timer sequence
+
+### 3. Socket-to-player mappings
+Today mappings are:
+- `socketToRoom`
+- `socketToPlayer`
+
+Add a room/player lookup path for resume validation, likely by scanning room slots or keeping:
+- `playerIdToRoom`
+- `token lookup` not required globally; room-scoped lookup is enough
+
+### 4. Shared payload model
+Current payloads do not expose reserved/disconnected or paused-reconnect metadata. Add a shared reconnect view duplicated into lobby/game payloads.
+
+Recommended shape:
+
+```ts
+interface ReconnectStateView {
+  active: boolean;
+  status: 'none' | 'waiting-for-player' | 'resume-countdown';
+  disconnectedSlotIndex: 0 | 1 | null;
+  reservedUntil: number | null;
+  secondsRemaining: number | null;
+  canResumeAutomatically: boolean;
+}
+```
+
+This should be included in:
+- `LobbyStatePayload`
+- `PublicGameStatePayload`
+- `GameRematchStatePayload`
+- optionally `GameEndedPayload.finalState` via the embedded game state
+
+### 5. Client state/rendering
+The client should remain largely server-driven.
+
+Add a tiny local session manager that:
+- stores reconnect token on successful room assignment
+- attempts `session:resume` on socket reconnect if token exists
+- clears token when server says room/session is no longer valid
+
+UI changes should be purely derived from authoritative payloads:
+- reserved player badge in lobby/rematch
+- reconnect countdown message for both players
+- paused gameplay overlay with “Waiting for Player X to reconnect”
+- resume countdown once player returns
+
+Do **not** let the client assume reconnect success merely because the socket transport reconnected.
+
+## Edge case handling
+
+### Multiple disconnects within the window
+If the same slot disconnects repeatedly:
+- overwrite `socketId = null`
+- refresh `disconnectedAt`
+- refresh `reservationExpiresAt = now + 30s`
+- keep same reconnect token
+
+This is acceptable and matches user expectation.
+
+### Reconnect just before timeout
+The resume path should check `now <= reservationExpiresAt` on the server. If valid, reclaim wins even if local UI timer visually appears almost expired.
+
+### Missing local token after refresh
+If browser lost storage or token is absent:
+- automatic reclaim is impossible
+- room stays reserved until timeout
+- player must wait for reopen or create/join a new room
+
+This is acceptable per scope.
+
+### Stale token after slot has been reopened and reused
+If a token belongs to an old occupancy generation:
+- resume fails
+- client clears stale token
+- no slot hijack occurs because token must match current slot ownership and active reservation window
+
+### Both players disconnect during gameplay pause
+If second player disconnects while first is reserved:
+- room no longer has a remaining connected player
+- simplest MVP rule: dispose room
+- no winner needs to be declared because no active claimant remains to observe result
+
+### Server restart during reservation
+All reconnect windows are lost because room state is in memory. Client resume will fail with room/session not found. This matches current architecture constraints and should be documented, not solved here.
+
+## Recommended implementation order
+1. Extend shared contracts with session resume payloads and reconnect view.
+2. Refactor `PlayerSlot` and `RoomRecord` for reservation/token state.
+3. Mint/store reconnect tokens on create/join.
+4. Add `session:resume` command and success/failure handling.
+5. Refactor disconnect path for lobby/game-over reservation semantics.
+6. Add gameplay/countdown pause + timeout-forfeit flow.
+7. Update client session storage and reconnect UX.
+8. Add tests for reservation, resume, expiry, gameplay pause, and room reopen paths.
+
+## Test scenarios the dev agent must cover
+1. lobby disconnect reserves slot for 30 seconds
+2. lobby reconnect with valid token reclaims same slot
+3. lobby timeout reopens slot for replacement join
+4. countdown disconnect pauses start and reconnect resumes cleanly
+5. gameplay disconnect pauses match and broadcasts reconnect state
+6. gameplay reconnect resumes same frozen board state
+7. gameplay timeout awards connected player the win
+8. game-over disconnect reserves slot, clears rematch acceptance, and timeout reopens slot
+9. invalid or stale token cannot reclaim slot
+10. reconnecting just before expiry still succeeds
+11. repeated disconnect/reconnect cycles do not corrupt room version or duplicate timers
+
+## Guidance for the next agent
+Implement this as a **minimal, room-scoped identity layer** rather than a general auth system. Preserve existing room and match flow where possible. The critical correctness points are:
+
+- slot ownership survives socket loss for 30 seconds
+- only the server decides whether reclaim is allowed
+- countdown/tick timers stop while waiting on reconnect
+- timeout behavior differs by phase: gameplay/countdown => forfeit, lobby/game-over => reopen slot
+- post-game/rematch stays reusable after timeout
+- client UI is derived from authoritative reconnect state, not transport reconnect alone

--- a/docs/impl/disconnect-reconnect-handling/dev-notes.md
+++ b/docs/impl/disconnect-reconnect-handling/dev-notes.md
@@ -1,0 +1,13 @@
+# Development notes
+
+## Implemented
+- Added room-scoped reconnect tokens issued on create/join and resumed through a new `session:resume` socket event.
+- Refactored room occupancy to preserve slot ownership independently from `socketId`, including reserved/disconnected slot metadata and a 30-second reservation window.
+- Added authoritative reconnect state to lobby, game, and rematch payloads so the UI can show reserved slots, reconnect countdowns, and paused match state.
+- Changed disconnect handling so lobby and post-game disconnects reserve the slot before reopening it on timeout, while countdown/in-progress disconnects pause the match and award a disconnect forfeit if the player does not return in time.
+- Updated the browser client to persist reconnect tokens in local storage, auto-attempt session resume on reconnect, and surface reconnect/resume messaging in lobby and gameplay states.
+- Expanded `RoomService` coverage with reconnect-focused tests for lobby resume, paused-game resume countdowns, post-game reservation behavior, and disconnect forfeits after timeout.
+
+## Notes / deviations
+- Resume after a paused countdown or live game currently uses a fresh server-driven 3-second resume countdown rather than restoring sub-second timer precision from the exact interrupted countdown tick. This keeps the flow authoritative and predictable while staying within the approved UX intent.
+- The repository did not have `subtask` / `agent:fullstack-dev` labels configured, so the implementation subtask was created and linked without those labels.

--- a/docs/impl/disconnect-reconnect-handling/dev-notes.md
+++ b/docs/impl/disconnect-reconnect-handling/dev-notes.md
@@ -11,3 +11,4 @@
 ## Notes / deviations
 - Resume after a paused countdown or live game currently uses a fresh server-driven 3-second resume countdown rather than restoring sub-second timer precision from the exact interrupted countdown tick. This keeps the flow authoritative and predictable while staying within the approved UX intent.
 - The repository did not have `subtask` / `agent:fullstack-dev` labels configured, so the implementation subtask was created and linked without those labels.
+- Review fix: `room:join` no longer treats `game-over` rooms with a reserved reconnect slot as mid-match; post-game join attempts now fall through to the occupancy check and return `ROOM_FULL`, with regression coverage updated to lock in the API-contract behavior.

--- a/docs/impl/disconnect-reconnect-handling/qa-report.md
+++ b/docs/impl/disconnect-reconnect-handling/qa-report.md
@@ -1,0 +1,48 @@
+# QA report — Disconnect / reconnect handling
+
+## Summary
+- **Parent issue:** #63
+- **PR:** #66
+- **Branch:** `feature/issue-63`
+- **Feature slug:** `disconnect-reconnect-handling`
+- **Environment:** `http://20.106.185.110:8081/`
+- **QA verdict:** **PASS**
+- **Test date (UTC):** 2026-03-12
+- **Method:** Live end-to-end socket-level validation against the deployed dev environment using real multi-client reconnect flows.
+
+## Artifacts reviewed
+- Parent issue #63 spec
+- `docs/impl/disconnect-reconnect-handling/spec.md`
+- `docs/impl/disconnect-reconnect-handling/design.md`
+- `docs/impl/disconnect-reconnect-handling/dev-notes.md`
+- `docs/impl/disconnect-reconnect-handling/deploy-log.md`
+- PR #66 changed files list
+
+## Test scenarios executed
+1. Lobby disconnect reserves slot and same-browser/device reconnect reclaims the same slot.
+2. Lobby disconnect timeout reopens the reserved slot after 30 seconds.
+3. Gameplay disconnect pauses the match, shows reconnect-waiting state, and resumes after reconnect.
+4. Gameplay disconnect timeout awards the connected player the win.
+5. Post-game/rematch disconnect reserves the slot, disables rematch while reserved, and reopens the slot after timeout.
+
+## Acceptance criteria results
+
+| AC | Requirement | Result | Evidence |
+|---|---|---|---|
+| 1 | If a player disconnects in lobby state, their slot is reserved for 30 seconds. | PASS | In room `OKTH`, disconnecting Player 2 caused lobby reconnect state to become active immediately with `secondsRemaining: 30` and `disconnectedSlotIndex: 1`. |
+| 2 | If that player reconnects within 30 seconds from the same browser/device, they automatically reclaim their same slot. | PASS | In room `OKTH`, Player 2 resumed with the original reconnect token and received `session:resume:succeeded` with `slotIndex: 1`; lobby returned to two occupied players with no manual recovery step. |
+| 3 | If the player does not reconnect in time from lobby/rematch state, the slot reopens. | PASS | In room `NMSJ`, the lobby returned to `phase: waiting-for-players` with Player 2 unoccupied after timeout. In room `IWIV`, post-game/rematch timeout also returned the room to `waiting-for-players` with Player 2 slot reopened. |
+| 4 | If a player disconnects during active gameplay, the match pauses and clearly shows reconnect-waiting state. | PASS | In room `OZSC`, disconnecting Player 2 during active play produced `game:state` with `phase: in-progress`, `paused: true`, reconnect active, and reconnect status `waiting-for-player`. |
+| 5 | If the disconnected gameplay player reconnects within 30 seconds, the match resumes. | PASS | In room `OZSC`, Player 2 resumed with the original reconnect token, a server-driven resume countdown was emitted, and the game returned to `paused: false` with reconnect inactive. |
+| 6 | If the disconnected gameplay player does not reconnect within 30 seconds, the remaining player is declared the winner. | PASS | In room `SKIQ`, after Player 2 stayed disconnected past timeout, `game:ended` declared `winnerSlotIndex: 0` with death reason `{ slotIndex: 1, reason: 'disconnect' }`. |
+| 7 | Reconnect identity works via same browser/device local session token. | PASS | Both lobby (`OKTH`) and gameplay (`OZSC`) recovery succeeded only by presenting the stored reconnect token and reclaimed the original slot automatically. |
+| 8 | The reconnect flow works across lobby, gameplay, and post-game/rematch states. | PASS | Verified in lobby (`OKTH`, `NMSJ`), active gameplay (`OZSC`, `SKIQ`), and post-game/rematch (`IWIV`). |
+| 9 | The experience is understandable to both the disconnected and remaining player. | PASS | Observed explicit reconnect state transitions and timer-driven behavior in lobby/game/rematch payloads: reserved slot messaging, reconnect-active states, paused gameplay, resume countdown, rematch unavailable while waiting, and timeout reopening / forfeit resolution. |
+
+## Notes
+- The gameplay resume path emitted a server-driven resume countdown and resumed correctly. The first observed countdown event in QA was `0`, which is consistent with joining the countdown stream after it started rather than a UX defect.
+- QA was performed through live socket interactions against the deployed build rather than a browser UI session, but the emitted state and transitions matched the expected player-facing behavior described in the spec and deployment notes.
+- No defects or blockers were found during the required acceptance-criteria coverage.
+
+## Verdict
+**PASS** — Issue #63 meets the approved disconnect / reconnect handling acceptance criteria in the current dev deployment.

--- a/docs/impl/disconnect-reconnect-handling/review-cycle-1.md
+++ b/docs/impl/disconnect-reconnect-handling/review-cycle-1.md
@@ -1,0 +1,42 @@
+# Review Cycle 1 — PR #66
+
+## Verdict
+CHANGES_REQUESTED
+
+## What I reviewed
+- Spec: `docs/impl/disconnect-reconnect-handling/spec.md`
+- Design: `docs/impl/disconnect-reconnect-handling/design.md`
+- API contracts: `docs/impl/disconnect-reconnect-handling/api-contracts.md`
+- Dev notes: `docs/impl/disconnect-reconnect-handling/dev-notes.md`
+- Implementation diff in PR #66
+- Validation: `npm test` and `npm run build`
+
+## Findings
+
+### 1. Reserved post-game slot returns the wrong join error
+- **Severity:** medium
+- **Area:** reconnect / lobby-rematch reopen behavior
+- **Files:** `src/server/roomService.ts`
+
+#### Problem
+The API contract says a reserved slot is unavailable to replacement joiners and ordinary `room:join` should fail with `ROOM_FULL` while that reservation is active. The current implementation returns `GAME_ALREADY_STARTED` whenever a `game-over` room still has two owned slots:
+
+```ts
+if (room.phase === 'game-over' && room.players.every((player) => player.playerId)) {
+  return { events: [this.error(socketId, 'GAME_ALREADY_STARTED')] };
+}
+```
+
+That branch also fires when one player is disconnected but still reserved, so the join path reports the room as if it were mid-match instead of accurately reflecting that the room is full because the reconnect reservation is still in force.
+
+#### Why it matters
+- Violates the documented contract in `api-contracts.md`.
+- Misstates room state to the client during the reconnect window.
+- Makes the rematch/lobby reopen flow harder to reason about because replacement joins fail for the wrong reason.
+
+#### Required fix
+Change the `game-over` join gate so reserved slots fail as `ROOM_FULL`, while true active-match states continue to use `GAME_ALREADY_STARTED`. Add a test covering `room:join` against a post-game reserved slot and asserting `ROOM_FULL`.
+
+## Notes
+- Reconnect token issuance, slot reservation, pause/forfeit timeout handling, and resume countdown behavior generally line up with the approved design.
+- Test suite passed after installing dependencies locally with `npm ci`.

--- a/docs/impl/disconnect-reconnect-handling/review-cycle-2.md
+++ b/docs/impl/disconnect-reconnect-handling/review-cycle-2.md
@@ -1,0 +1,51 @@
+# Review Cycle 2 — PR #66
+
+## Verdict
+APPROVED
+
+## What I reviewed
+- Previous review: `docs/impl/disconnect-reconnect-handling/review-cycle-1.md`
+- Spec: `docs/impl/disconnect-reconnect-handling/spec.md`
+- API contracts: `docs/impl/disconnect-reconnect-handling/api-contracts.md`
+- Dev notes: `docs/impl/disconnect-reconnect-handling/dev-notes.md`
+- Updated implementation in `src/server/roomService.ts`
+- Updated regression coverage in `src/server/__tests__/roomService.test.ts`
+- Validation: `npm test -- src/server/__tests__/roomService.test.ts` and `npm run build`
+
+## Findings
+
+### 1. Post-game reserved-slot join now returns the correct contract error
+- **Status:** fixed
+- **Files:** `src/server/roomService.ts`
+
+The blocking mismatch from cycle 1 is resolved. The special-case `game-over` guard that previously returned `GAME_ALREADY_STARTED` for any room with two owned slots is gone. The join path now only rejects `starting` / `in-progress` rooms with `GAME_ALREADY_STARTED`, then falls through to the occupancy check:
+
+```ts
+if (room.phase === 'starting' || room.phase === 'in-progress') {
+  return { events: [this.error(socketId, 'GAME_ALREADY_STARTED')] };
+}
+
+const emptySlot = room.players.find((player) => !player.playerId);
+if (!emptySlot) return { events: [this.error(socketId, 'ROOM_FULL')] };
+```
+
+That means a `game-over` room with a disconnected-but-reserved player now correctly reports `ROOM_FULL`, which matches the documented reserved-slot semantics.
+
+### 2. Regression test meaningfully covers the reported bug
+- **Status:** sufficient
+- **Files:** `src/server/__tests__/roomService.test.ts`
+
+The updated test exercises the exact scenario that was wrong before:
+1. create room
+2. join second player
+3. transition to `game-over`
+4. disconnect one player so the slot becomes reserved
+5. attempt replacement `room:join`
+6. assert `room:error.reason === 'ROOM_FULL'`
+
+That is a direct contract-level regression test for the post-game reserved-slot join behavior, not just an indirect assertion on room state.
+
+## Notes
+- I did not find a remaining issue in the targeted `ROOM_FULL` vs `GAME_ALREADY_STARTED` behavior.
+- The updated post-game disconnect test also confirms rematch remains unavailable while the reconnect reservation is active, which is consistent with the intended flow.
+- Repo note: the GitHub labels expected by the ticketing skill do not appear to be configured here, so the review subtask was created and linked without labels.

--- a/docs/impl/disconnect-reconnect-handling/spec.md
+++ b/docs/impl/disconnect-reconnect-handling/spec.md
@@ -1,0 +1,109 @@
+# Feature Spec: Disconnect / Reconnect Handling
+
+## Status
+Draft for stakeholder approval
+
+## Feature Summary
+As a player, I want temporary disconnects and page refreshes to be handled gracefully so that a match or room is not unnecessarily ruined when someone drops and returns.
+
+## Scope
+In scope for this feature:
+- disconnect detection
+- reconnect flow for players returning to an existing room/session
+- preserving room/match continuity during temporary disconnects
+- player-facing status for disconnected/reconnecting states
+- timeout-based slot reservation
+- reconnect behavior across lobby, gameplay, and post-game/rematch states
+- automatic slot reclaim on successful reconnect
+
+Out of scope for this feature:
+- account-based identity across devices
+- long-term persistence
+- spectator mode
+- matchmaking recovery across unrelated rooms
+- full offline mode
+- reconnect across unrelated browsers/devices without local session continuity
+
+## Stakeholder Decisions Captured
+- Disconnect reservation timeout is **30 seconds**.
+- During active gameplay, the match should **pause briefly**, then the remaining player should win if the disconnected player does not return in time.
+- If the player reconnects in time, they should **automatically reclaim the same slot**.
+- If gameplay timeout expires, the **remaining player wins**.
+- In lobby and rematch states, the disconnected player’s slot should be reserved for the timeout and then reopened.
+- Reconnect identity for MVP should use **same browser/device via local session token**.
+
+## Assumptions
+- Reconnect handling will rely on a short-lived local session token stored client-side.
+- The server remains authoritative over slot ownership and reconnect eligibility.
+- A brief gameplay pause should be clearly communicated to both players.
+- Automatic slot reclaim means no extra manual reconnect confirmation is required if the same browser/device returns with a valid token.
+
+## User Scenarios
+
+### Scenario 1: Reconnect during lobby
+**As a player**, I want to reconnect to my room after a brief disconnect so I don’t lose my place.
+
+#### Expected behavior
+- If I disconnect briefly in the lobby, my slot is reserved for 30 seconds.
+- The other player sees that I am temporarily disconnected.
+- If I return within 30 seconds from the same browser/device, I automatically reclaim my same slot.
+- If I do not return in time, my slot reopens.
+
+### Scenario 2: Reconnect during active gameplay
+**As a player**, I want the game to handle a disconnect predictably so the match outcome feels fair.
+
+#### Expected behavior
+- If a player disconnects during active gameplay, the match pauses briefly.
+- The UI communicates that reconnect is being awaited.
+- If the player returns within the allowed reconnect window, they automatically resume in their same slot.
+- If they do not return in time, the remaining player wins.
+
+### Scenario 3: Reconnect after game over / during rematch
+**As a player**, I want reconnect behavior to still make sense after a round ends so rematch flow is not unnecessarily lost.
+
+#### Expected behavior
+- If a player disconnects in post-game/rematch state, their slot is reserved for 30 seconds.
+- The remaining player sees that the other player can still return.
+- If the disconnected player does not return in time, the slot reopens.
+
+## Functional Requirements
+1. The system must detect player disconnects.
+2. The system must communicate disconnect state to the remaining player.
+3. The system must reserve a disconnected player’s slot for 30 seconds.
+4. The system must allow a reconnecting player from the same browser/device to automatically reclaim their same slot via local session token.
+5. The server must remain authoritative over reconnect eligibility and slot reclaim.
+6. During active gameplay, a disconnect must trigger a temporary pause state.
+7. If the disconnected gameplay player reconnects within the timeout, gameplay must resume consistently.
+8. If the disconnected gameplay player does not reconnect within the timeout, the remaining player must win.
+9. In lobby state, if the disconnected player does not return within the timeout, the slot must reopen.
+10. In post-game/rematch state, if the disconnected player does not return within the timeout, the slot must reopen.
+11. The reconnect flow must work without requiring a user account system for MVP.
+
+## Non-Functional Requirements
+- Reconnect handling should reduce frustration from brief network interruptions.
+- The rules should be predictable and easy for players to understand.
+- The reconnect flow must not depend on full authentication for MVP.
+- Pause/reconnect status should be visually clear in the UI.
+
+## Edge Cases
+- A player refreshes during countdown.
+- A player disconnects and reconnects multiple times within the timeout window.
+- A player reconnects just before timeout expiry.
+- The remaining player leaves while waiting for the disconnected player.
+- A local session token is missing or invalid after refresh.
+
+## Acceptance Criteria
+1. If a player disconnects in lobby state, their slot is reserved for 30 seconds.
+2. If that player reconnects within 30 seconds from the same browser/device, they automatically reclaim their same slot.
+3. If the player does not reconnect in time from lobby/rematch state, the slot reopens.
+4. If a player disconnects during active gameplay, the match pauses and clearly shows reconnect-waiting state.
+5. If the disconnected gameplay player reconnects within 30 seconds, the match resumes.
+6. If the disconnected gameplay player does not reconnect within 30 seconds, the remaining player is declared the winner.
+7. Reconnect identity works via same browser/device local session token.
+8. The reconnect flow works across lobby, gameplay, and post-game/rematch states.
+9. The experience is understandable to both the disconnected and remaining player.
+
+## Open Notes for Implementation
+- The UI should make timeout and reconnect status explicit.
+- The pause state during gameplay should feel intentional, not like a broken match.
+- Local token handling should be lightweight and scoped to MVP needs.

--- a/docs/specs/disconnect-reconnect-handling.md
+++ b/docs/specs/disconnect-reconnect-handling.md
@@ -1,0 +1,109 @@
+# Feature Spec: Disconnect / Reconnect Handling
+
+## Status
+Draft for stakeholder approval
+
+## Feature Summary
+As a player, I want temporary disconnects and page refreshes to be handled gracefully so that a match or room is not unnecessarily ruined when someone drops and returns.
+
+## Scope
+In scope for this feature:
+- disconnect detection
+- reconnect flow for players returning to an existing room/session
+- preserving room/match continuity during temporary disconnects
+- player-facing status for disconnected/reconnecting states
+- timeout-based slot reservation
+- reconnect behavior across lobby, gameplay, and post-game/rematch states
+- automatic slot reclaim on successful reconnect
+
+Out of scope for this feature:
+- account-based identity across devices
+- long-term persistence
+- spectator mode
+- matchmaking recovery across unrelated rooms
+- full offline mode
+- reconnect across unrelated browsers/devices without local session continuity
+
+## Stakeholder Decisions Captured
+- Disconnect reservation timeout is **30 seconds**.
+- During active gameplay, the match should **pause briefly**, then the remaining player should win if the disconnected player does not return in time.
+- If the player reconnects in time, they should **automatically reclaim the same slot**.
+- If gameplay timeout expires, the **remaining player wins**.
+- In lobby and rematch states, the disconnected player’s slot should be reserved for the timeout and then reopened.
+- Reconnect identity for MVP should use **same browser/device via local session token**.
+
+## Assumptions
+- Reconnect handling will rely on a short-lived local session token stored client-side.
+- The server remains authoritative over slot ownership and reconnect eligibility.
+- A brief gameplay pause should be clearly communicated to both players.
+- Automatic slot reclaim means no extra manual reconnect confirmation is required if the same browser/device returns with a valid token.
+
+## User Scenarios
+
+### Scenario 1: Reconnect during lobby
+**As a player**, I want to reconnect to my room after a brief disconnect so I don’t lose my place.
+
+#### Expected behavior
+- If I disconnect briefly in the lobby, my slot is reserved for 30 seconds.
+- The other player sees that I am temporarily disconnected.
+- If I return within 30 seconds from the same browser/device, I automatically reclaim my same slot.
+- If I do not return in time, my slot reopens.
+
+### Scenario 2: Reconnect during active gameplay
+**As a player**, I want the game to handle a disconnect predictably so the match outcome feels fair.
+
+#### Expected behavior
+- If a player disconnects during active gameplay, the match pauses briefly.
+- The UI communicates that reconnect is being awaited.
+- If the player returns within the allowed reconnect window, they automatically resume in their same slot.
+- If they do not return in time, the remaining player wins.
+
+### Scenario 3: Reconnect after game over / during rematch
+**As a player**, I want reconnect behavior to still make sense after a round ends so rematch flow is not unnecessarily lost.
+
+#### Expected behavior
+- If a player disconnects in post-game/rematch state, their slot is reserved for 30 seconds.
+- The remaining player sees that the other player can still return.
+- If the disconnected player does not return in time, the slot reopens.
+
+## Functional Requirements
+1. The system must detect player disconnects.
+2. The system must communicate disconnect state to the remaining player.
+3. The system must reserve a disconnected player’s slot for 30 seconds.
+4. The system must allow a reconnecting player from the same browser/device to automatically reclaim their same slot via local session token.
+5. The server must remain authoritative over reconnect eligibility and slot reclaim.
+6. During active gameplay, a disconnect must trigger a temporary pause state.
+7. If the disconnected gameplay player reconnects within the timeout, gameplay must resume consistently.
+8. If the disconnected gameplay player does not reconnect within the timeout, the remaining player must win.
+9. In lobby state, if the disconnected player does not return within the timeout, the slot must reopen.
+10. In post-game/rematch state, if the disconnected player does not return within the timeout, the slot must reopen.
+11. The reconnect flow must work without requiring a user account system for MVP.
+
+## Non-Functional Requirements
+- Reconnect handling should reduce frustration from brief network interruptions.
+- The rules should be predictable and easy for players to understand.
+- The reconnect flow must not depend on full authentication for MVP.
+- Pause/reconnect status should be visually clear in the UI.
+
+## Edge Cases
+- A player refreshes during countdown.
+- A player disconnects and reconnects multiple times within the timeout window.
+- A player reconnects just before timeout expiry.
+- The remaining player leaves while waiting for the disconnected player.
+- A local session token is missing or invalid after refresh.
+
+## Acceptance Criteria
+1. If a player disconnects in lobby state, their slot is reserved for 30 seconds.
+2. If that player reconnects within 30 seconds from the same browser/device, they automatically reclaim their same slot.
+3. If the player does not reconnect in time from lobby/rematch state, the slot reopens.
+4. If a player disconnects during active gameplay, the match pauses and clearly shows reconnect-waiting state.
+5. If the disconnected gameplay player reconnects within 30 seconds, the match resumes.
+6. If the disconnected gameplay player does not reconnect within 30 seconds, the remaining player is declared the winner.
+7. Reconnect identity works via same browser/device local session token.
+8. The reconnect flow works across lobby, gameplay, and post-game/rematch states.
+9. The experience is understandable to both the disconnected and remaining player.
+
+## Open Notes for Implementation
+- The UI should make timeout and reconnect status explicit.
+- The pause state during gameplay should feel intentional, not like a broken match.
+- Local token handling should be lightweight and scoped to MVP needs.

--- a/public/app.js
+++ b/public/app.js
@@ -52,6 +52,7 @@ let boardReady = false;
 let buildMarkerText = 'Build: loading…';
 let buildMarkerTitle = 'Build metadata is loading.';
 let pendingDirection = null;
+let latestSession = null;
 
 const viewportState = {
   layoutMode: 'desktop',
@@ -90,9 +91,12 @@ window.addEventListener('orientationchange', updateViewportState);
 renderAudioToggle();
 
 socket.on('connect', () => {
-  statusEl.textContent = 'Connected. Create a room or join with a code.';
-  applyPhaseTheme('entry', 'neutral');
-  showScreen('entry');
+  const resumed = tryResumeStoredSession();
+  statusEl.textContent = resumed ? 'Connected. Trying to resume your room…' : 'Connected. Create a room or join with a code.';
+  if (!resumed) {
+    applyPhaseTheme('entry', 'neutral');
+    showScreen('entry');
+  }
 });
 
 socket.on('room:error', (payload) => {
@@ -112,6 +116,25 @@ socket.on('room:joined', (payload) => {
   errorEl.classList.add('hidden');
   statusEl.textContent = 'Joined room.';
   audioManager.play('ui.click');
+});
+
+socket.on('session:issued', (payload) => {
+  latestSession = payload;
+  storeSession(payload);
+});
+
+socket.on('session:resume:succeeded', (payload) => {
+  statusEl.textContent = 'Session restored.';
+  gameStatusInlineEl.textContent = payload.phase === 'in-progress' ? 'Reconnected. Waiting for server resume…' : 'Reconnected.';
+});
+
+socket.on('session:resume:failed', (payload) => {
+  clearStoredSession(payload.roomCode);
+  latestSession = null;
+  statusEl.textContent = 'Reconnect window expired. You can create or join a room again.';
+  gameStatusInlineEl.textContent = statusEl.textContent;
+  applyPhaseTheme('entry', 'neutral');
+  showScreen('entry');
 });
 
 socket.on('player:left', () => {
@@ -211,6 +234,62 @@ document.getElementById('joinRoomButton').addEventListener('click', () => {
   audioManager.play('ui.click');
   socket.emit('room:join', { roomCode: roomCodeInput.value });
 });
+
+function sessionStorageKey(roomCode) {
+  return `snake:session:${String(roomCode || '').toUpperCase()}`;
+}
+
+function storeSession(payload) {
+  if (!payload?.roomCode || !payload?.reconnectToken) return;
+  const record = {
+    roomCode: payload.roomCode,
+    reconnectToken: payload.reconnectToken,
+    slotIndex: payload.slotIndex,
+    issuedAt: payload.issuedAt,
+    version: payload.version,
+  };
+  localStorage.setItem(sessionStorageKey(payload.roomCode), JSON.stringify(record));
+}
+
+function clearStoredSession(roomCode) {
+  if (!roomCode) return;
+  localStorage.removeItem(sessionStorageKey(roomCode));
+}
+
+function getStoredSession() {
+  const roomCode = latestLobbyState?.roomCode || latestGameState?.roomCode || latestSession?.roomCode;
+  if (roomCode) {
+    const raw = localStorage.getItem(sessionStorageKey(roomCode));
+    if (raw) {
+      try { return JSON.parse(raw); } catch { return null; }
+    }
+  }
+
+  const key = Object.keys(localStorage).find((entry) => entry.startsWith('snake:session:'));
+  if (!key) return null;
+  try { return JSON.parse(localStorage.getItem(key)); } catch { return null; }
+}
+
+function tryResumeStoredSession() {
+  const stored = getStoredSession();
+  if (!stored?.roomCode || !stored?.reconnectToken) return false;
+  latestSession = stored;
+  socket.emit('session:resume', { roomCode: stored.roomCode, reconnectToken: stored.reconnectToken });
+  return true;
+}
+
+function describeReconnect(state) {
+  const reconnect = state?.reconnect;
+  if (!reconnect?.active) return '';
+  const label = reconnect.disconnectedSlotIndex === null || reconnect.disconnectedSlotIndex === undefined
+    ? 'Player'
+    : `Player ${reconnect.disconnectedSlotIndex + 1}`;
+  const seconds = reconnect.secondsRemaining ?? 0;
+  if (reconnect.status === 'resume-countdown') return `${label} reconnected. Resuming in ${seconds}s.`;
+  return reconnect.yourSlotReserved
+    ? `Rejoining your reserved slot. ${seconds}s remaining.`
+    : `${label} disconnected. Slot reserved for ${seconds}s.`;
+}
 
 function focusWithoutScroll(element) {
   if (!element || typeof element.focus !== 'function') {
@@ -365,7 +444,7 @@ function renderLobby(state) {
   roomCodeDisplay.textContent = state.roomCode;
   gameRoomCodeEl.textContent = state.roomCode;
   phaseBadge.textContent = formatPhaseLabel(state.phase);
-  lobbyMessage.textContent = state.message || '';
+  lobbyMessage.textContent = describeReconnect(state) || state.message || '';
   playersEl.innerHTML = '';
 
   const gameplayFocused = state.phase === 'starting' || state.phase === 'in-progress' || state.phase === 'game-over';
@@ -378,9 +457,9 @@ function renderLobby(state) {
     card.innerHTML = `
       <div class="player-meta">
         <strong>${player.label}${player.isYou ? ' (You)' : ''}</strong>
-        <span>${player.isOccupied ? 'Joined' : 'Waiting'}</span>
+        <span>${player.isOccupied ? (player.isReserved ? 'Reserved' : player.isConnected ? 'Joined' : 'Disconnected') : 'Waiting'}</span>
       </div>
-      <div class="player-state">${player.isOccupied ? (player.isReady ? 'Ready to launch' : 'Not ready yet') : 'Open slot'}</div>
+      <div class="player-state">${player.isOccupied ? (player.isReserved ? 'Reconnect window active' : player.isConnected ? (player.isReady ? 'Ready to launch' : 'Not ready yet') : 'Temporarily offline') : 'Open slot'}</div>
     `;
     playersEl.appendChild(card);
   }
@@ -392,16 +471,16 @@ function renderLobby(state) {
 
   if (gameplayFocused) {
     gamePhaseLabel.textContent = state.phase === 'starting' ? 'Countdown' : state.phase === 'game-over' ? 'Game over' : 'In progress';
-    gameStatusInlineEl.textContent = state.phase === 'starting'
+    gameStatusInlineEl.textContent = describeReconnect(state) || (state.phase === 'starting'
       ? 'Match starts in moments.'
       : state.phase === 'game-over'
         ? 'Round complete.'
-        : 'Game live.';
-    gameMessageEl.textContent = state.phase === 'starting'
+        : 'Game live.');
+    gameMessageEl.textContent = describeReconnect(state) || (state.phase === 'starting'
       ? 'Both players are ready. Transitioning into gameplay.'
       : state.phase === 'game-over'
         ? 'Round finished. Choose rematch or wait for room changes.'
-        : 'Gameplay screen active. Lobby is fully hidden during the match.';
+        : 'Gameplay screen active. Lobby is fully hidden during the match.');
   }
 
   renderRematch(state.rematch, state.phase);
@@ -486,9 +565,9 @@ function renderGame(state, perSlotResult) {
     applyPhaseTheme('countdown', 'neutral');
   } else if (state.phase === 'in-progress') {
     gamePhaseLabel.textContent = 'In progress';
-    gameStatusInlineEl.textContent = 'Game live.';
+    gameStatusInlineEl.textContent = describeReconnect(state) || 'Game live.';
     countdownLabel.textContent = `Tick: ${state.tickNumber}`;
-    gameMessageEl.textContent = 'Avoid walls, avoid bodies, and race for the shared food.';
+    gameMessageEl.textContent = describeReconnect(state) || 'Avoid walls, avoid bodies, and race for the shared food.';
     applyPhaseTheme('live', 'neutral');
   } else {
     gamePhaseLabel.textContent = 'Game over';

--- a/src/server/__tests__/roomService.test.ts
+++ b/src/server/__tests__/roomService.test.ts
@@ -205,7 +205,7 @@ describe("RoomService", () => {
     expect(gameState.food).not.toBeNull();
   });
 
-  test("post-game leave keeps the room open and clears stale rematch state", () => {
+  test("post-game disconnect reserves the slot and keeps rematch unavailable", () => {
     const service = new RoomService();
     const roomCode = payloads(service.createRoom("socket-a"), "room:created")[0]
       .roomCode;
@@ -214,19 +214,17 @@ describe("RoomService", () => {
     service.requestRematch("socket-a");
 
     const leaveResult = service.disconnect("socket-b");
-    const left = payloads(leaveResult, "player:left")[0];
     const lobby = payloads(leaveResult, "lobby:state")[0];
     const rematch = payloads(leaveResult, "game:rematch-state")[0];
 
-    expect(left.reason).toBe("disconnected");
-    expect(lobby.phase).toBe("waiting-for-players");
-    expect(lobby.roomCode).toBe(roomCode);
+    expect(lobby.phase).toBe("game-over");
+    expect(lobby.reconnect.active).toBe(true);
+    expect(lobby.players[1].isReserved).toBe(true);
     expect(rematch.rematch.available).toBe(false);
-    expect(rematch.rematch.requestedBySlot[0]).toBe(false);
-    expect(rematch.rematch.requestedBySlot[1]).toBe(false);
+    expect(rematch.reconnect.active).toBe(true);
   });
 
-  test("replacement join after post-game leave returns room to normal lobby flow", () => {
+  test("replacement join is blocked while a post-game slot is reserved", () => {
     const service = new RoomService();
     const roomCode = payloads(service.createRoom("socket-a"), "room:created")[0]
       .roomCode;
@@ -235,16 +233,12 @@ describe("RoomService", () => {
     service.disconnect("socket-b");
 
     const joinResult = service.joinRoom("socket-c", roomCode);
-    const lobby = payloads(joinResult, "lobby:state").at(-1);
+    const error = payloads(joinResult, "room:error")[0];
 
-    expect(lobby.phase).toBe("lobby");
-    expect(lobby.roomCode).toBe(roomCode);
-    expect(lobby.rematch.available).toBe(false);
-    expect(lobby.players[1].isOccupied).toBe(true);
-    expect(lobby.canStart).toBe(false);
+    expect(error.reason).toBe("GAME_ALREADY_STARTED");
   });
 
-  test("disconnect during gameplay ends the round but does not close the room", () => {
+  test("disconnect during gameplay pauses first, then awards forfeit after timeout", () => {
     const emitted: Array<{ type: string; payload: any }> = [];
     const service = new RoomService();
     service.setEventSink((events) => emitted.push(...events));
@@ -257,14 +251,54 @@ describe("RoomService", () => {
     vi.advanceTimersByTime(3000);
 
     const disconnectResult = service.disconnect("socket-b");
-    const ended = payloads(disconnectResult, "game:ended");
+    const pausedState = payloads(disconnectResult, "game:state")[0];
+    expect(pausedState.paused).toBe(true);
+    expect(pausedState.reconnect.active).toBe(true);
+
+    vi.advanceTimersByTime(30000);
+    const ended = emitted.filter((event) => event.type === "game:ended").map((event) => event.payload as any);
     expect(ended).toHaveLength(1);
     expect(ended[0].result.winnerSlotIndex).toBe(0);
     expect(ended[0].result.bySlot[0]).toBe("win");
     expect(ended[0].result.bySlot[1]).toBe("lose");
+  });
 
+  test("resume succeeds during lobby and restores the same slot", () => {
+    const service = new RoomService();
+    const created = service.createRoom("socket-a");
+    const roomCode = payloads(created, "room:created")[0].roomCode;
+    const hostSession = payloads(created, "session:issued")[0];
+    service.joinRoom("socket-b", roomCode);
+    const disconnectResult = service.disconnect("socket-a");
+    expect(payloads(disconnectResult, "lobby:state")[0].reconnect.active).toBe(true);
+
+    const resumeResult = service.resumeSession("socket-a-2", { roomCode, reconnectToken: hostSession.reconnectToken });
+    const resumed = payloads(resumeResult, "session:resume:succeeded")[0];
+    const lobby = payloads(resumeResult, "lobby:state")[0];
+    expect(resumed.slotIndex).toBe(0);
+    expect(lobby.yourSlotIndex).toBe(0);
+    expect(lobby.reconnect.active).toBe(false);
+  });
+
+  test("resume during gameplay starts a server-driven resume countdown", () => {
+    const service = new RoomService();
+    const created = service.createRoom("socket-a");
+    const roomCode = payloads(created, "room:created")[0].roomCode;
+    const joined = service.joinRoom("socket-b", roomCode);
+    const guestSession = payloads(joined, "session:issued")[0];
+    service.setReady("socket-a", true);
+    service.setReady("socket-b", true);
     vi.advanceTimersByTime(3000);
-    const roomClosed = emitted.filter((event) => event.type === "room:closed");
-    expect(roomClosed).toHaveLength(0);
+
+    const disconnectResult = service.disconnect("socket-b");
+    expect(payloads(disconnectResult, "game:state")[0].paused).toBe(true);
+
+    const resumeResult = service.resumeSession("socket-b-2", { roomCode, reconnectToken: guestSession.reconnectToken });
+    expect(payloads(resumeResult, "session:resume:succeeded")[0].slotIndex).toBe(1);
+    const countdowns = payloads(resumeResult, "game:countdown");
+    expect(countdowns).toHaveLength(2);
+    expect(countdowns[0].secondsRemaining).toBe(3);
+    const gameStates = payloads(resumeResult, "game:state");
+    expect(gameStates[0].reconnect.status).toBe("resume-countdown");
   });
 });

--- a/src/server/__tests__/roomService.test.ts
+++ b/src/server/__tests__/roomService.test.ts
@@ -235,7 +235,7 @@ describe("RoomService", () => {
     const joinResult = service.joinRoom("socket-c", roomCode);
     const error = payloads(joinResult, "room:error")[0];
 
-    expect(error.reason).toBe("GAME_ALREADY_STARTED");
+    expect(error.reason).toBe("ROOM_FULL");
   });
 
   test("disconnect during gameplay pauses first, then awards forfeit after timeout", () => {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -66,6 +66,11 @@ io.on('connection', (socket) => {
     emitEvents(roomService.setDirection(socket.id, payload.direction));
   });
 
+  socket.on(EVENTS.sessionResume, (payload: { roomCode?: string; reconnectToken?: string }) => {
+    if (!payload?.roomCode || !payload?.reconnectToken) return;
+    emitEvents(roomService.resumeSession(socket.id, { roomCode: payload.roomCode, reconnectToken: payload.reconnectToken }).events);
+  });
+
   socket.on(EVENTS.gameRematchRequest, () => {
     emitEvents(roomService.requestRematch(socket.id).events);
   });

--- a/src/server/roomService.ts
+++ b/src/server/roomService.ts
@@ -1,3 +1,4 @@
+import { randomBytes } from 'node:crypto';
 import type {
   Direction,
   GameCountdownPayload,
@@ -8,12 +9,17 @@ import type {
   LobbyErrorReason,
   LobbyStatePayload,
   PlayerLeftPayload,
+  PlayerSessionPayload,
   RematchView,
+  ReconnectView,
   RoomClosedPayload,
   RoomCreatedPayload,
   RoomJoinedPayload,
   RoomPhase,
-} from "../shared/contracts.js";
+  SessionResumeFailedPayload,
+  SessionResumeRequestPayload,
+  SessionResumeSucceededPayload,
+} from '../shared/contracts.js';
 import {
   applyDisconnectResult,
   advanceOneTick,
@@ -21,7 +27,26 @@ import {
   queueDirectionInput,
   toOutcomeForSlot,
   type MatchState,
-} from "./gameLogic.js";
+} from './gameLogic.js';
+
+const RECONNECT_WINDOW_MS = 30_000;
+const RESUME_COUNTDOWN_MS = 3_000;
+
+type ClientEventType =
+  | 'room:created'
+  | 'room:joined'
+  | 'lobby:state'
+  | 'room:error'
+  | 'player:left'
+  | 'game:countdown'
+  | 'game:start'
+  | 'game:state'
+  | 'game:ended'
+  | 'game:rematch-state'
+  | 'room:closed'
+  | 'session:issued'
+  | 'session:resume:succeeded'
+  | 'session:resume:failed';
 
 interface PlayerSlot {
   slotIndex: 0 | 1;
@@ -29,10 +54,26 @@ interface PlayerSlot {
   socketId: string | null;
   connected: boolean;
   ready: boolean;
+  reconnectToken: string | null;
+  disconnectedAt: number | null;
+  reservationExpiresAt: number | null;
 }
 
 interface RematchState {
   requestedBySlot: { 0: boolean; 1: boolean };
+}
+
+interface DisconnectWindow {
+  slotIndex: 0 | 1;
+  startedAt: number;
+  expiresAt: number;
+  affectedPhase: RoomPhase;
+}
+
+interface PausedMatchState {
+  pausedAt: number;
+  disconnectedSlotIndex: 0 | 1;
+  phaseToResume: 'starting' | 'in-progress';
 }
 
 interface RoomRecord {
@@ -49,21 +90,12 @@ interface RoomRecord {
   } | null;
   teardownAt: number | null;
   rematch: RematchState;
+  disconnectWindow: DisconnectWindow | null;
+  pausedMatch: PausedMatchState | null;
 }
 
 export interface ClientEvent {
-  type:
-    | "room:created"
-    | "room:joined"
-    | "lobby:state"
-    | "room:error"
-    | "player:left"
-    | "game:countdown"
-    | "game:start"
-    | "game:state"
-    | "game:ended"
-    | "game:rematch-state"
-    | "room:closed";
+  type: ClientEventType;
   socketId: string;
   payload: unknown;
 }
@@ -76,6 +108,7 @@ interface RuntimeRecord {
   countdownTimers: NodeJS.Timeout[];
   tickTimer: NodeJS.Timeout | null;
   teardownTimer: NodeJS.Timeout | null;
+  reservationTimer: NodeJS.Timeout | null;
 }
 
 export class RoomService {
@@ -91,74 +124,80 @@ export class RoomService {
   }
 
   createRoom(socketId: string): ServiceResult {
-    this.leaveCurrentRoom(socketId, "left");
-
+    this.leaveCurrentRoom(socketId, 'left');
     const roomCode = this.generateUniqueRoomCode();
     const playerId = this.allocatePlayerId();
+    const issuedAt = Date.now();
     const room: RoomRecord = {
       roomCode,
-      phase: "waiting-for-players",
-      createdAt: Date.now(),
+      phase: 'waiting-for-players',
+      createdAt: issuedAt,
       version: 1,
       match: null,
       countdown: null,
       teardownAt: null,
       rematch: { requestedBySlot: { 0: false, 1: false } },
+      disconnectWindow: null,
+      pausedMatch: null,
       players: [
-        { slotIndex: 0, playerId, socketId, connected: true, ready: false },
+        {
+          slotIndex: 0,
+          playerId,
+          socketId,
+          connected: true,
+          ready: false,
+          reconnectToken: this.generateReconnectToken(),
+          disconnectedAt: null,
+          reservationExpiresAt: null,
+        },
         {
           slotIndex: 1,
           playerId: null,
           socketId: null,
           connected: false,
           ready: false,
+          reconnectToken: null,
+          disconnectedAt: null,
+          reservationExpiresAt: null,
         },
       ],
     };
-
     this.rooms.set(roomCode, room);
     this.socketToRoom.set(socketId, roomCode);
     this.socketToPlayer.set(socketId, playerId);
 
     return {
       events: [
-        {
-          type: "room:created",
-          socketId,
-          payload: { roomCode, yourSlotIndex: 0 } satisfies RoomCreatedPayload,
-        },
+        { type: 'room:created', socketId, payload: { roomCode, yourSlotIndex: 0 } satisfies RoomCreatedPayload },
+        this.buildSessionIssuedEvent(room, room.players[0], socketId, issuedAt),
         ...this.buildLobbyStateEvents(room),
       ],
     };
   }
 
   joinRoom(socketId: string, rawRoomCode: string): ServiceResult {
-    this.leaveCurrentRoom(socketId, "left");
-
+    this.leaveCurrentRoom(socketId, 'left');
     const roomCode = this.normalizeRoomCode(rawRoomCode);
-    if (!this.isValidRoomCode(roomCode))
-      return { events: [this.error(socketId, "INVALID_ROOM_CODE")] };
-
+    if (!this.isValidRoomCode(roomCode)) return { events: [this.error(socketId, 'INVALID_ROOM_CODE')] };
     const room = this.rooms.get(roomCode);
-    if (!room) return { events: [this.error(socketId, "ROOM_NOT_FOUND")] };
-    if (room.phase === "starting" || room.phase === "in-progress") {
-      return { events: [this.error(socketId, "GAME_ALREADY_STARTED")] };
-    }
-    if (
-      room.phase === "game-over" &&
-      room.players.every((player) => player.playerId)
-    ) {
-      return { events: [this.error(socketId, "GAME_ALREADY_STARTED")] };
+    if (!room) return { events: [this.error(socketId, 'ROOM_NOT_FOUND')] };
+    if (room.phase === 'starting' || room.phase === 'in-progress') return { events: [this.error(socketId, 'GAME_ALREADY_STARTED')] };
+    if (room.phase === 'game-over' && room.players.every((player) => player.playerId)) {
+      return { events: [this.error(socketId, 'GAME_ALREADY_STARTED')] };
     }
 
     const emptySlot = room.players.find((player) => !player.playerId);
-    if (!emptySlot) return { events: [this.error(socketId, "ROOM_FULL")] };
+    if (!emptySlot) return { events: [this.error(socketId, 'ROOM_FULL')] };
 
     const playerId = this.allocatePlayerId();
+    const issuedAt = Date.now();
     emptySlot.playerId = playerId;
     emptySlot.socketId = socketId;
     emptySlot.connected = true;
     emptySlot.ready = false;
+    emptySlot.reconnectToken = this.generateReconnectToken();
+    emptySlot.disconnectedAt = null;
+    emptySlot.reservationExpiresAt = null;
     this.socketToRoom.set(socketId, roomCode);
     this.socketToPlayer.set(socketId, playerId);
     this.clearRematchState(room);
@@ -167,70 +206,92 @@ export class RoomService {
 
     return {
       events: [
-        {
-          type: "room:joined",
-          socketId,
-          payload: {
-            roomCode,
-            yourSlotIndex: emptySlot.slotIndex,
-          } satisfies RoomJoinedPayload,
-        },
+        { type: 'room:joined', socketId, payload: { roomCode, yourSlotIndex: emptySlot.slotIndex } satisfies RoomJoinedPayload },
+        this.buildSessionIssuedEvent(room, emptySlot, socketId, issuedAt),
         ...this.afterLobbyMutation(room),
       ],
     };
   }
 
-  setReady(socketId: string, ready: boolean): ServiceResult {
-    const room = this.getRoomForSocket(socketId);
-    if (
-      !room ||
-      (room.phase !== "waiting-for-players" && room.phase !== "lobby")
-    ) {
-      return { events: [this.error(socketId, "ACTION_NOT_ALLOWED")] };
+  resumeSession(socketId: string, payload: SessionResumeRequestPayload): ServiceResult {
+    this.leaveCurrentRoom(socketId, 'left');
+    const roomCode = this.normalizeRoomCode(payload.roomCode);
+    const room = this.rooms.get(roomCode);
+    if (!room) return { events: [this.resumeError(socketId, roomCode, 'ROOM_NOT_FOUND', 'Room no longer exists.')] };
+
+    const slot = room.players.find((player) => player.reconnectToken === payload.reconnectToken);
+    if (!slot) return { events: [this.resumeError(socketId, roomCode, 'TOKEN_MISMATCH', 'Reconnect token did not match this room.')] };
+    if (!slot.reservationExpiresAt || slot.connected) {
+      return { events: [this.resumeError(socketId, roomCode, slot.connected ? 'SLOT_ALREADY_ACTIVE' : 'SLOT_NOT_RESERVED', slot.connected ? 'That slot is already active.' : 'That slot is not reserved for reconnect.')] };
+    }
+    if (slot.reservationExpiresAt <= Date.now()) {
+      this.expireReservation(room.roomCode, slot.slotIndex, true);
+      return { events: [this.resumeError(socketId, roomCode, 'RESERVATION_EXPIRED', 'Reconnect window expired. That slot is no longer reserved.')] };
     }
 
-    const player = room.players.find((slot) => slot.socketId === socketId);
-    if (!player)
-      return { events: [this.error(socketId, "ACTION_NOT_ALLOWED")] };
+    slot.socketId = socketId;
+    slot.connected = true;
+    slot.disconnectedAt = null;
+    slot.ready = room.phase === 'game-over' ? slot.ready : false;
+    this.socketToRoom.set(socketId, roomCode);
+    this.socketToPlayer.set(socketId, slot.playerId!);
+    if (!room.pausedMatch) {
+      this.clearReservation(room, slot.slotIndex);
+    }
+    room.version += 1;
 
+    const resumedAt = Date.now();
+    const events: ClientEvent[] = [
+      {
+        type: 'session:resume:succeeded',
+        socketId,
+        payload: {
+          roomCode,
+          slotIndex: slot.slotIndex,
+          phase: room.phase,
+          resumedAt,
+          version: room.version,
+        } satisfies SessionResumeSucceededPayload,
+      },
+    ];
+
+    if (room.pausedMatch) {
+      events.push(...this.startResumeCountdown(room));
+    } else {
+      if (room.phase !== 'game-over') room.phase = this.computePhase(room);
+      events.push(...this.buildLobbyStateEvents(room));
+      events.push(...this.buildGameStateEvents(room));
+      events.push(...this.buildRematchStateEvents(room));
+    }
+    return { events };
+  }
+
+  setReady(socketId: string, ready: boolean): ServiceResult {
+    const room = this.getRoomForSocket(socketId);
+    if (!room || (room.phase !== 'waiting-for-players' && room.phase !== 'lobby') || room.disconnectWindow) {
+      return { events: [this.error(socketId, 'ACTION_NOT_ALLOWED')] };
+    }
+    const player = room.players.find((slot) => slot.socketId === socketId);
+    if (!player) return { events: [this.error(socketId, 'ACTION_NOT_ALLOWED')] };
     player.ready = ready;
     room.version += 1;
     room.phase = this.computePhase(room);
-
     return { events: this.afterLobbyMutation(room) };
   }
 
   requestRematch(socketId: string): ServiceResult {
     const room = this.getRoomForSocket(socketId);
-    if (!room || room.phase !== "game-over")
-      return { events: [this.error(socketId, "ACTION_NOT_ALLOWED")] };
-
+    if (!room || room.phase !== 'game-over' || room.disconnectWindow) return { events: [this.error(socketId, 'ACTION_NOT_ALLOWED')] };
     const player = room.players.find((slot) => slot.socketId === socketId);
-    if (!player)
-      return { events: [this.error(socketId, "ACTION_NOT_ALLOWED")] };
-
-    if (room.rematch.requestedBySlot[player.slotIndex]) {
-      return { events: [] };
-    }
+    if (!player) return { events: [this.error(socketId, 'ACTION_NOT_ALLOWED')] };
+    if (room.rematch.requestedBySlot[player.slotIndex]) return { events: [] };
 
     room.rematch.requestedBySlot[player.slotIndex] = true;
     room.version += 1;
+    const events = [...this.buildLobbyStateEvents(room), ...this.buildGameStateEvents(room), ...this.buildRematchStateEvents(room)];
+    if (!this.areBothPlayersPresent(room) || !room.rematch.requestedBySlot[0] || !room.rematch.requestedBySlot[1]) return { events };
 
-    const events = [
-      ...this.buildLobbyStateEvents(room),
-      ...this.buildGameStateEvents(room),
-      ...this.buildRematchStateEvents(room),
-    ];
-
-    if (
-      !this.areBothPlayersPresent(room) ||
-      !room.rematch.requestedBySlot[0] ||
-      !room.rematch.requestedBySlot[1]
-    ) {
-      return { events };
-    }
-
-    room.phase = "starting";
+    room.phase = 'starting';
     room.version += 1;
     room.match = createInitialMatchState(room.roomCode);
     room.countdown = null;
@@ -239,189 +300,204 @@ export class RoomService {
       slot.ready = false;
     });
     this.clearRematchState(room);
-
-    const now = Date.now();
-    room.countdown = {
-      startedAt: now,
-      endsAt: now + 3000,
-      secondsRemaining: 3,
-    };
-    events.push(...this.buildLobbyStateEvents(room));
-    events.push(...this.buildGameStateEvents(room, 3));
-    events.push(...this.buildCountdownEvents(room, 3, now));
-    events.push(...this.buildRematchStateEvents(room));
-    this.startCountdown(room.roomCode);
+    events.push(...this.beginCountdown(room, 3000));
     return { events };
   }
 
   setDirection(socketId: string, direction: Direction): ServiceResult {
     const room = this.getRoomForSocket(socketId);
-    if (
-      !room ||
-      !room.match ||
-      (room.phase !== "starting" && room.phase !== "in-progress")
-    ) {
-      return { events: [this.error(socketId, "ACTION_NOT_ALLOWED")] };
+    if (!room || !room.match || (room.phase !== 'starting' && room.phase !== 'in-progress') || room.pausedMatch || room.disconnectWindow) {
+      return { events: [this.error(socketId, 'ACTION_NOT_ALLOWED')] };
     }
-
     const player = room.players.find((slot) => slot.socketId === socketId);
-    if (!player)
-      return { events: [this.error(socketId, "ACTION_NOT_ALLOWED")] };
-
-    const queued = queueDirectionInput(
-      room.match.snakes[player.slotIndex],
-      direction,
-    );
-    return queued
-      ? { events: [] }
-      : { events: [this.error(socketId, "ACTION_NOT_ALLOWED")] };
+    if (!player) return { events: [this.error(socketId, 'ACTION_NOT_ALLOWED')] };
+    const queued = queueDirectionInput(room.match.snakes[player.slotIndex], direction);
+    return queued ? { events: [] } : { events: [this.error(socketId, 'ACTION_NOT_ALLOWED')] };
   }
 
   disconnect(socketId: string): ServiceResult {
-    return this.leaveCurrentRoom(socketId, "disconnected");
+    return this.leaveCurrentRoom(socketId, 'disconnected');
   }
 
-  private leaveCurrentRoom(
-    socketId: string,
-    reason: "left" | "disconnected",
-  ): ServiceResult {
+  private leaveCurrentRoom(socketId: string, reason: 'left' | 'disconnected'): ServiceResult {
     const roomCode = this.socketToRoom.get(socketId);
     if (!roomCode) return { events: [] };
-
     const room = this.rooms.get(roomCode);
     this.socketToRoom.delete(socketId);
     this.socketToPlayer.delete(socketId);
     if (!room) return { events: [] };
-
-    const leavingPlayer = room.players.find(
-      (slot) => slot.socketId === socketId,
-    );
+    const leavingPlayer = room.players.find((slot) => slot.socketId === socketId);
     if (!leavingPlayer) return { events: [] };
 
-    const slotIndex = leavingPlayer.slotIndex;
+    if (reason === 'left') {
+      return this.removePlayerCompletely(room, leavingPlayer.slotIndex, reason);
+    }
+    return this.reserveDisconnectedPlayer(room, leavingPlayer.slotIndex);
+  }
+
+  private removePlayerCompletely(room: RoomRecord, slotIndex: 0 | 1, reason: 'left' | 'disconnected'): ServiceResult {
+    const leavingPlayer = room.players[slotIndex];
     leavingPlayer.playerId = null;
     leavingPlayer.socketId = null;
     leavingPlayer.connected = false;
     leavingPlayer.ready = false;
+    leavingPlayer.reconnectToken = null;
+    leavingPlayer.disconnectedAt = null;
+    leavingPlayer.reservationExpiresAt = null;
+    if (room.disconnectWindow?.slotIndex === slotIndex) this.clearReservation(room, slotIndex);
 
     const remainingPlayers = room.players.filter((slot) => slot.playerId);
     if (remainingPlayers.length === 0) {
-      this.disposeRoom(roomCode);
+      this.disposeRoom(room.roomCode);
       return { events: [] };
     }
 
-    if (room.phase === "starting" || room.phase === "in-progress") {
-      const events = this.finishMatch(
-        room,
-        applyDisconnectResult(room.match!, slotIndex, Date.now()),
-        reason === "disconnected" ? "player-disconnected" : "round-complete",
-      );
+    if (room.phase === 'starting' || room.phase === 'in-progress') {
+      const events = this.finishMatch(room, applyDisconnectResult(room.match!, slotIndex, Date.now()), reason === 'disconnected' ? 'player-disconnected' : 'round-complete');
       return { events };
     }
 
-    remainingPlayers[0].ready = false;
+    remainingPlayers.forEach((slot) => {
+      slot.ready = false;
+    });
     this.clearRematchState(room);
     room.countdown = null;
-    if (room.phase === "game-over") {
+    room.pausedMatch = null;
+    if (room.phase === 'game-over') {
       room.match = null;
       room.teardownAt = null;
     }
     room.version += 1;
-    room.phase = "waiting-for-players";
+    room.phase = 'waiting-for-players';
 
-    const events: ClientEvent[] = remainingPlayers.flatMap((slot) => [
-      {
-        type: "player:left",
-        socketId: slot.socketId!,
-        payload: { roomCode, slotIndex, reason } satisfies PlayerLeftPayload,
-      },
-    ]);
+    const events: ClientEvent[] = remainingPlayers.flatMap((slot) =>
+      slot.socketId
+        ? [{ type: 'player:left', socketId: slot.socketId, payload: { roomCode: room.roomCode, slotIndex, reason } satisfies PlayerLeftPayload }]
+        : [],
+    );
     events.push(...this.buildLobbyStateEvents(room));
     events.push(...this.buildRematchStateEvents(room));
     return { events };
   }
 
-  private afterLobbyMutation(room: RoomRecord): ClientEvent[] {
-    const events = this.buildLobbyStateEvents(room);
-    if (!this.canStart(room)) return events;
+  private reserveDisconnectedPlayer(room: RoomRecord, slotIndex: 0 | 1): ServiceResult {
+    const leavingPlayer = room.players[slotIndex];
+    leavingPlayer.socketId = null;
+    leavingPlayer.connected = false;
+    leavingPlayer.ready = false;
+    leavingPlayer.disconnectedAt = Date.now();
+    leavingPlayer.reservationExpiresAt = leavingPlayer.disconnectedAt + RECONNECT_WINDOW_MS;
+    const remainingPlayers = room.players.filter((slot) => slot.playerId && slot.connected);
+    if (remainingPlayers.length === 0) {
+      this.disposeRoom(room.roomCode);
+      return { events: [] };
+    }
 
-    room.phase = "starting";
-    room.version += 1;
-    room.match = createInitialMatchState(room.roomCode);
-    room.countdown = null;
     this.clearRematchState(room);
+    room.version += 1;
+    room.disconnectWindow = {
+      slotIndex,
+      startedAt: leavingPlayer.disconnectedAt,
+      expiresAt: leavingPlayer.reservationExpiresAt,
+      affectedPhase: room.phase,
+    };
+
+    if (room.phase === 'starting' || room.phase === 'in-progress') {
+      room.pausedMatch = {
+        pausedAt: Date.now(),
+        disconnectedSlotIndex: slotIndex,
+        phaseToResume: room.phase,
+      };
+      this.cancelActiveProgress(room.roomCode);
+    }
+
+    remainingPlayers.forEach((slot) => {
+      if (room.phase !== 'game-over') slot.ready = false;
+    });
+
+    this.scheduleReservationExpiry(room.roomCode, slotIndex, RECONNECT_WINDOW_MS);
+    return { events: this.buildSnapshotEvents(room) };
+  }
+
+  private startResumeCountdown(room: RoomRecord): ClientEvent[] {
+    room.version += 1;
+    const events = this.beginCountdown(room, RESUME_COUNTDOWN_MS);
+    return events;
+  }
+
+  private beginCountdown(room: RoomRecord, durationMs: number): ClientEvent[] {
+    room.phase = 'starting';
     const now = Date.now();
     room.countdown = {
       startedAt: now,
-      endsAt: now + 3000,
+      endsAt: now + durationMs,
       secondsRemaining: 3,
     };
-    events.push(...this.buildLobbyStateEvents(room));
-    events.push(...this.buildGameStateEvents(room, 3));
-    events.push(...this.buildCountdownEvents(room, 3, now));
-    events.push(...this.buildRematchStateEvents(room));
-
+    const events = [
+      ...this.buildLobbyStateEvents(room),
+      ...this.buildGameStateEvents(room, 3),
+      ...this.buildCountdownEvents(room, 3, now),
+      ...this.buildRematchStateEvents(room),
+    ];
     this.startCountdown(room.roomCode);
     return events;
   }
 
+  private afterLobbyMutation(room: RoomRecord): ClientEvent[] {
+    const events = this.buildLobbyStateEvents(room);
+    if (!this.canStart(room)) return events;
+    room.match = createInitialMatchState(room.roomCode);
+    room.version += 1;
+    this.clearRematchState(room);
+    events.push(...this.beginCountdown(room, 3000));
+    return events;
+  }
+
   private startCountdown(roomCode: string) {
-    this.cancelRuntime(roomCode);
-    const runtime: RuntimeRecord = {
-      countdownTimers: [],
-      tickTimer: null,
-      teardownTimer: null,
-    };
     const room = this.rooms.get(roomCode);
     if (!room || !room.countdown) return;
+    const runtime = this.ensureRuntime(roomCode);
+    runtime.countdownTimers.forEach(clearTimeout);
+    runtime.countdownTimers = [];
 
     ([2, 1, 0] as const).forEach((second, index) => {
-      const timer = setTimeout(
-        () => {
-          const activeRoom = this.rooms.get(roomCode);
-          if (
-            !activeRoom ||
-            activeRoom.phase !== "starting" ||
-            !activeRoom.countdown ||
-            !activeRoom.match
-          )
-            return;
-          activeRoom.countdown.secondsRemaining = second;
-          activeRoom.version += 1;
-          const now = Date.now();
-          const events: ClientEvent[] = [
-            ...this.buildLobbyStateEvents(activeRoom),
-            ...this.buildGameStateEvents(activeRoom, second),
-            ...this.buildCountdownEvents(activeRoom, second, now),
-            ...this.buildRematchStateEvents(activeRoom),
-          ];
-          if (second === 0) {
-            events.push(...this.beginActiveMatch(activeRoom, now));
-          }
-          this.emitExternal(events);
-        },
-        (index + 1) * 1000,
-      );
+      const timer = setTimeout(() => {
+        const activeRoom = this.rooms.get(roomCode);
+        if (!activeRoom || activeRoom.phase !== 'starting' || !activeRoom.countdown || !activeRoom.match || activeRoom.disconnectWindow) return;
+        activeRoom.countdown.secondsRemaining = second;
+        activeRoom.version += 1;
+        const now = Date.now();
+        const events: ClientEvent[] = [
+          ...this.buildLobbyStateEvents(activeRoom),
+          ...this.buildGameStateEvents(activeRoom, second),
+          ...this.buildCountdownEvents(activeRoom, second, now),
+          ...this.buildRematchStateEvents(activeRoom),
+        ];
+        if (second === 0) {
+          events.push(...this.beginActiveMatch(activeRoom, now));
+        }
+        this.emitExternal(events);
+      }, (index + 1) * 1000);
       runtime.countdownTimers.push(timer);
     });
-
-    this.runtimes.set(roomCode, runtime);
   }
 
   private beginActiveMatch(room: RoomRecord, now: number): ClientEvent[] {
     if (!room.match) return [];
-    room.phase = "in-progress";
+    room.phase = 'in-progress';
     room.version += 1;
     room.countdown = null;
-    room.match.status = "active";
+    room.pausedMatch = null;
+    this.clearReservation(room);
+    room.match.status = 'active';
     room.match.startedAt = now;
     const payload: GameStartPayload = {
       roomCode: room.roomCode,
-      phase: "in-progress",
+      phase: 'in-progress',
       board: room.match.board,
       players: [
-        { slotIndex: 0, label: "Player 1" },
-        { slotIndex: 1, label: "Player 2" },
+        { slotIndex: 0, label: 'Player 1' },
+        { slotIndex: 1, label: 'Player 2' },
       ],
       tickIntervalMs: room.match.tickIntervalMs,
       startedAt: now,
@@ -429,23 +505,21 @@ export class RoomService {
     };
     const events = this.buildLobbyStateEvents(room);
     for (const player of room.players) {
-      if (player.socketId)
-        events.push({ type: "game:start", socketId: player.socketId, payload });
+      if (player.socketId) events.push({ type: 'game:start', socketId: player.socketId, payload });
     }
     this.scheduleNextTick(room.roomCode, room.match.tickIntervalMs);
     return events;
   }
 
   private scheduleNextTick(roomCode: string, delayMs: number) {
-    const runtime = this.runtimes.get(roomCode);
-    if (!runtime) return;
+    const runtime = this.ensureRuntime(roomCode);
     runtime.tickTimer = setTimeout(() => {
       const room = this.rooms.get(roomCode);
-      if (!room || room.phase !== "in-progress" || !room.match) return;
+      if (!room || room.phase !== 'in-progress' || !room.match || room.pausedMatch || room.disconnectWindow) return;
       room.match = advanceOneTick(room.match, Date.now());
       room.version += 1;
       if (room.match.result) {
-        this.emitExternal(this.finishMatch(room, room.match, "round-complete"));
+        this.emitExternal(this.finishMatch(room, room.match, 'round-complete'));
         return;
       }
       this.emitExternal(this.buildGameStateEvents(room));
@@ -453,27 +527,23 @@ export class RoomService {
     }, delayMs);
   }
 
-  private finishMatch(
-    room: RoomRecord,
-    match: MatchState,
-    closeReason: "round-complete" | "player-disconnected",
-  ): ClientEvent[] {
+  private finishMatch(room: RoomRecord, match: MatchState, closeReason: 'round-complete' | 'player-disconnected'): ClientEvent[] {
     room.match = match;
-    room.phase = "game-over";
+    room.phase = 'game-over';
     room.version += 1;
     room.teardownAt = null;
+    room.countdown = null;
+    room.pausedMatch = null;
+    this.clearReservation(room);
     this.clearRematchState(room);
-    this.cancelRuntime(room.roomCode);
+    this.cancelActiveProgress(room.roomCode);
 
     const finalState = this.serializeGameState(room);
     const payload: GameEndedPayload = {
       roomCode: room.roomCode,
-      phase: "game-over",
+      phase: 'game-over',
       result: {
-        bySlot: {
-          0: toOutcomeForSlot(match, 0),
-          1: toOutcomeForSlot(match, 1),
-        },
+        bySlot: { 0: toOutcomeForSlot(match, 0), 1: toOutcomeForSlot(match, 1) },
         winnerSlotIndex: match.winnerSlotIndex,
         deathReasons: match.deathReasons,
       },
@@ -484,20 +554,69 @@ export class RoomService {
 
     const events = this.buildLobbyStateEvents(room);
     events.push(...this.buildGameStateEvents(room));
-    events.push(
-      ...this.buildRematchStateEvents(
-        room,
-        closeReason === "player-disconnected"
-          ? "Opponent disconnected. Room stays open for another player."
-          : "Round complete. Choose rematch to play again.",
-      ),
-    );
+    events.push(...this.buildRematchStateEvents(room, closeReason === 'player-disconnected' ? 'Opponent forfeited by disconnect.' : 'Round complete. Choose rematch to play again.'));
     for (const player of room.players) {
-      if (player.socketId)
-        events.push({ type: "game:ended", socketId: player.socketId, payload });
+      if (player.socketId) events.push({ type: 'game:ended', socketId: player.socketId, payload });
+    }
+    return events;
+  }
+
+  private expireReservation(roomCode: string, slotIndex: 0 | 1, silent = false) {
+    const room = this.rooms.get(roomCode);
+    if (!room) return;
+    const reservedPlayer = room.players[slotIndex];
+    if (!reservedPlayer.playerId || reservedPlayer.connected || room.disconnectWindow?.slotIndex !== slotIndex) return;
+
+    if (room.disconnectWindow.affectedPhase === 'starting' || room.disconnectWindow.affectedPhase === 'in-progress') {
+      const events = this.finishMatch(room, applyDisconnectResult(room.match!, slotIndex, Date.now()), 'player-disconnected');
+      if (!silent) this.emitExternal(events);
+      return;
     }
 
-    return events;
+    const events = this.removePlayerCompletely(room, slotIndex, 'disconnected').events;
+    if (!silent) this.emitExternal(events);
+  }
+
+  private scheduleReservationExpiry(roomCode: string, slotIndex: 0 | 1, delayMs: number) {
+    const runtime = this.ensureRuntime(roomCode);
+    if (runtime.reservationTimer) clearTimeout(runtime.reservationTimer);
+    runtime.reservationTimer = setTimeout(() => this.expireReservation(roomCode, slotIndex), delayMs);
+  }
+
+  private clearReservation(room: RoomRecord, slotIndex?: 0 | 1) {
+    if (slotIndex !== undefined) {
+      const player = room.players[slotIndex];
+      player.disconnectedAt = null;
+      player.reservationExpiresAt = null;
+    }
+    room.disconnectWindow = null;
+    const runtime = this.runtimes.get(room.roomCode);
+    if (runtime?.reservationTimer) {
+      clearTimeout(runtime.reservationTimer);
+      runtime.reservationTimer = null;
+    }
+  }
+
+  private buildSnapshotEvents(room: RoomRecord): ClientEvent[] {
+    return [...this.buildLobbyStateEvents(room), ...this.buildGameStateEvents(room), ...this.buildRematchStateEvents(room)];
+  }
+
+  private cancelActiveProgress(roomCode: string) {
+    const runtime = this.ensureRuntime(roomCode);
+    runtime.countdownTimers.forEach(clearTimeout);
+    runtime.countdownTimers = [];
+    if (runtime.tickTimer) {
+      clearTimeout(runtime.tickTimer);
+      runtime.tickTimer = null;
+    }
+  }
+
+  private ensureRuntime(roomCode: string): RuntimeRecord {
+    const existing = this.runtimes.get(roomCode);
+    if (existing) return existing;
+    const runtime: RuntimeRecord = { countdownTimers: [], tickTimer: null, teardownTimer: null, reservationTimer: null };
+    this.runtimes.set(roomCode, runtime);
+    return runtime;
   }
 
   private cancelRuntime(roomCode: string) {
@@ -506,6 +625,7 @@ export class RoomService {
     for (const timer of existing.countdownTimers) clearTimeout(timer);
     if (existing.tickTimer) clearTimeout(existing.tickTimer);
     if (existing.teardownTimer) clearTimeout(existing.teardownTimer);
+    if (existing.reservationTimer) clearTimeout(existing.reservationTimer);
     this.runtimes.delete(roomCode);
   }
 
@@ -515,23 +635,11 @@ export class RoomService {
   }
 
   private buildLobbyStateEvents(room: RoomRecord): ClientEvent[] {
-    return room.players.flatMap((player) => {
-      if (!player.socketId) return [];
-      return [
-        {
-          type: "lobby:state" as const,
-          socketId: player.socketId,
-          payload: this.serializeLobbyState(room, player.socketId),
-        },
-      ];
-    });
+    return room.players.flatMap((player) => (player.socketId ? [{ type: 'lobby:state' as const, socketId: player.socketId, payload: this.serializeLobbyState(room, player.socketId) }] : []));
   }
 
-  private buildRematchStateEvents(
-    room: RoomRecord,
-    message?: string,
-  ): ClientEvent[] {
-    const phase = room.phase === "in-progress" ? null : room.phase;
+  private buildRematchStateEvents(room: RoomRecord, message?: string): ClientEvent[] {
+    const phase = room.phase === 'in-progress' ? null : room.phase;
     if (!phase) return [];
     return room.players.flatMap((player) => {
       if (!player.socketId) return [];
@@ -539,173 +647,113 @@ export class RoomService {
         roomCode: room.roomCode,
         phase,
         rematch: this.buildRematchView(room, player.socketId),
+        reconnect: this.buildReconnectView(room, player.socketId),
+        yourSlotIndex: player.slotIndex,
         version: room.version,
         message,
       };
-      return [
-        {
-          type: "game:rematch-state" as const,
-          socketId: player.socketId,
-          payload,
-        },
-      ];
+      return [{ type: 'game:rematch-state' as const, socketId: player.socketId, payload }];
     });
   }
 
-  private buildCountdownEvents(
-    room: RoomRecord,
-    secondsRemaining: 3 | 2 | 1 | 0,
-    now: number,
-  ): ClientEvent[] {
+  private buildCountdownEvents(room: RoomRecord, secondsRemaining: 3 | 2 | 1 | 0, now: number): ClientEvent[] {
     if (!room.countdown) return [];
     const payload: GameCountdownPayload = {
       roomCode: room.roomCode,
-      phase: "starting",
+      phase: 'starting',
       secondsRemaining,
       startsAt: room.countdown.startedAt,
       serverNow: now,
       version: room.version,
     };
-    return room.players.flatMap((player) =>
-      player.socketId
-        ? [
-            {
-              type: "game:countdown" as const,
-              socketId: player.socketId,
-              payload,
-            },
-          ]
-        : [],
-    );
+    return room.players.flatMap((player) => (player.socketId ? [{ type: 'game:countdown' as const, socketId: player.socketId, payload }] : []));
   }
 
-  private buildGameStateEvents(
-    room: RoomRecord,
-    countdownSecondsRemaining?: 3 | 2 | 1 | 0,
-  ): ClientEvent[] {
+  private buildGameStateEvents(room: RoomRecord, countdownSecondsRemaining?: 3 | 2 | 1 | 0): ClientEvent[] {
     if (!room.match) return [];
-    return room.players.flatMap((player) => {
-      if (!player.socketId) return [];
-      return [
-        {
-          type: "game:state" as const,
-          socketId: player.socketId,
-          payload: this.serializeGameState(
-            room,
-            player.socketId,
-            countdownSecondsRemaining,
-          ),
-        },
-      ];
-    });
+    return room.players.flatMap((player) => (player.socketId ? [{ type: 'game:state' as const, socketId: player.socketId, payload: this.serializeGameState(room, player.socketId, countdownSecondsRemaining) }] : []));
   }
 
-  private serializeLobbyState(
-    room: RoomRecord,
-    viewerSocketId: string,
-  ): LobbyStatePayload {
-    const occupiedCount = room.players.filter((player) => player.playerId)
-      .length as 0 | 1 | 2;
-    const allPlayersPresent = occupiedCount === 2;
-    const allReady =
-      allPlayersPresent && room.players.every((player) => player.ready);
-    const canStart = this.canStart(room);
-
+  private serializeLobbyState(room: RoomRecord, viewerSocketId: string): LobbyStatePayload {
+    const occupiedCount = room.players.filter((player) => player.playerId).length as 0 | 1 | 2;
+    const allPlayersPresent = occupiedCount === 2 && room.players.every((player) => player.connected);
+    const allReady = allPlayersPresent && room.players.every((player) => player.ready);
+    const viewer = room.players.find((player) => player.socketId === viewerSocketId) ?? null;
     return {
       roomCode: room.roomCode,
       phase: room.phase,
+      yourSlotIndex: viewer?.slotIndex ?? null,
       players: room.players.map((player) => ({
         slotIndex: player.slotIndex,
         isOccupied: Boolean(player.playerId),
         isReady: Boolean(player.playerId) && player.ready,
-        label: player.slotIndex === 0 ? "Player 1" : "Player 2",
+        isConnected: Boolean(player.connected),
+        isReserved: Boolean(player.playerId && !player.connected && player.reservationExpiresAt),
+        label: player.slotIndex === 0 ? 'Player 1' : 'Player 2',
         isYou: player.socketId === viewerSocketId,
-      })) as LobbyStatePayload["players"],
+      })) as LobbyStatePayload['players'],
       occupiedCount,
       allPlayersPresent,
       allReady,
-      canStart,
+      canStart: this.canStart(room),
       version: room.version,
       message: this.getLobbyMessage(room),
       rematch: this.buildRematchView(room, viewerSocketId),
+      reconnect: this.buildReconnectView(room, viewerSocketId),
     };
   }
 
-  private serializeGameState(
-    room: RoomRecord,
-    viewerSocketId?: string,
-    countdownSecondsRemaining?: 3 | 2 | 1 | 0,
-  ): GameStatePayload {
+  private serializeGameState(room: RoomRecord, viewerSocketId?: string, countdownSecondsRemaining?: 3 | 2 | 1 | 0): GameStatePayload {
     const match = room.match!;
+    const viewer = viewerSocketId ? room.players.find((slot) => slot.socketId === viewerSocketId) ?? null : null;
     return {
       roomCode: room.roomCode,
-      phase:
-        room.phase === "game-over"
-          ? "game-over"
-          : room.phase === "starting"
-            ? "starting"
-            : "in-progress",
+      phase: room.phase === 'game-over' ? 'game-over' : room.phase === 'starting' ? 'starting' : 'in-progress',
+      yourSlotIndex: viewer?.slotIndex ?? null,
       tickNumber: match.tickNumber,
       board: match.board,
       food: match.food,
-      snakes: match.snakes.map((snake) => ({
-        slotIndex: snake.slotIndex,
-        body: snake.body,
-        direction: snake.direction,
-        alive: snake.alive,
-        score: snake.score,
-      })) as GameStatePayload["snakes"],
+      snakes: match.snakes.map((snake) => ({ slotIndex: snake.slotIndex, body: snake.body, direction: snake.direction, alive: snake.alive, score: snake.score })) as GameStatePayload['snakes'],
       foodsEaten: match.foodsEaten,
       tickIntervalMs: match.tickIntervalMs,
       countdownSecondsRemaining,
-      result:
-        room.phase === "game-over"
-          ? {
-              outcome:
-                match.result === "draw"
-                  ? "draw"
-                  : match.winnerSlotIndex === 0
-                    ? "win"
-                    : "lose",
-              winnerSlotIndex: match.winnerSlotIndex,
-              deathReasons: match.deathReasons,
-            }
-          : undefined,
+      paused: Boolean(room.pausedMatch),
+      reconnect: this.buildReconnectView(room, viewerSocketId),
+      result: room.phase === 'game-over' ? {
+        outcome: match.result === 'draw' ? 'draw' : match.winnerSlotIndex === 0 ? 'win' : 'lose',
+        winnerSlotIndex: match.winnerSlotIndex,
+        deathReasons: match.deathReasons,
+      } : undefined,
       rematch: this.buildRematchView(room, viewerSocketId),
       version: room.version,
     };
   }
 
-  private buildRematchView(
-    room: RoomRecord,
-    viewerSocketId?: string,
-  ): RematchView {
-    const eligiblePlayerCount = room.players.filter(
-      (player) => player.playerId && player.connected,
-    ).length as 0 | 1 | 2;
-    const bothAccepted =
-      eligiblePlayerCount === 2 &&
-      room.rematch.requestedBySlot[0] &&
-      room.rematch.requestedBySlot[1];
-    const acceptedCount =
-      Number(room.rematch.requestedBySlot[0]) +
-      Number(room.rematch.requestedBySlot[1]);
-    const available = room.phase === "game-over" && eligiblePlayerCount === 2;
-    const viewer = viewerSocketId
-      ? room.players.find((slot) => slot.socketId === viewerSocketId)
-      : null;
-    const requestedByYou = viewer
-      ? room.rematch.requestedBySlot[viewer.slotIndex]
-      : false;
-    const waitingForOtherPlayer = available && requestedByYou && !bothAccepted;
-    const status = !available
-      ? "unavailable"
-      : bothAccepted
-        ? "accepted"
-        : acceptedCount === 1
-          ? "waiting"
-          : "idle";
+  private buildReconnectView(room: RoomRecord, viewerSocketId?: string): ReconnectView {
+    const viewer = viewerSocketId ? room.players.find((slot) => slot.socketId === viewerSocketId) ?? null : null;
+    const window = room.disconnectWindow;
+    const secondsRemaining = window ? Math.max(0, Math.ceil((window.expiresAt - Date.now()) / 1000)) : null;
+    return {
+      active: Boolean(window),
+      status: window ? (room.pausedMatch && room.players[window.slotIndex].connected ? 'resume-countdown' : 'waiting-for-player') : 'none',
+      disconnectedSlotIndex: window?.slotIndex ?? null,
+      reservedUntil: window?.expiresAt ?? null,
+      secondsRemaining,
+      affectedPhase: window?.affectedPhase ?? null,
+      yourSlotReserved: Boolean(viewer && window && viewer.slotIndex === window.slotIndex),
+      canAutoResume: Boolean(viewer && window && viewer.slotIndex === window.slotIndex),
+    };
+  }
 
+  private buildRematchView(room: RoomRecord, viewerSocketId?: string): RematchView {
+    const eligiblePlayerCount = room.players.filter((player) => player.playerId && player.connected).length as 0 | 1 | 2;
+    const bothAccepted = eligiblePlayerCount === 2 && room.rematch.requestedBySlot[0] && room.rematch.requestedBySlot[1];
+    const acceptedCount = Number(room.rematch.requestedBySlot[0]) + Number(room.rematch.requestedBySlot[1]);
+    const available = room.phase === 'game-over' && eligiblePlayerCount === 2 && !room.disconnectWindow;
+    const viewer = viewerSocketId ? room.players.find((slot) => slot.socketId === viewerSocketId) : null;
+    const requestedByYou = viewer ? room.rematch.requestedBySlot[viewer.slotIndex] : false;
+    const waitingForOtherPlayer = available && requestedByYou && !bothAccepted;
+    const status = !available ? 'unavailable' : bothAccepted ? 'accepted' : acceptedCount === 1 ? 'waiting' : 'idle';
     return {
       available,
       status,
@@ -718,39 +766,30 @@ export class RoomService {
   }
 
   private getLobbyMessage(room: RoomRecord): string {
-    if (room.phase === "starting" && room.countdown)
-      return `Match starts in ${room.countdown.secondsRemaining}…`;
-    if (room.phase === "in-progress") return "Match in progress.";
-    if (room.phase === "game-over")
-      return this.buildRematchView(room).available
-        ? "Round complete. Choose rematch to play again."
-        : "Round complete. Waiting for opponent status to change.";
-    return room.players.filter((player) => player.playerId).length === 2
-      ? "Game starts automatically when both players are ready."
-      : "Waiting for opponent.";
+    if (room.disconnectWindow) {
+      const label = room.disconnectWindow.slotIndex === 0 ? 'Player 1' : 'Player 2';
+      const seconds = Math.max(0, Math.ceil((room.disconnectWindow.expiresAt - Date.now()) / 1000));
+      if (room.pausedMatch) return `${label} disconnected. Waiting ${seconds}s for reconnect.`;
+      return `${label} disconnected. Slot reserved for ${seconds}s.`;
+    }
+    if (room.phase === 'starting' && room.countdown) return `Match starts in ${room.countdown.secondsRemaining}…`;
+    if (room.phase === 'in-progress') return 'Match in progress.';
+    if (room.phase === 'game-over') return this.buildRematchView(room).available ? 'Round complete. Choose rematch to play again.' : 'Round complete. Waiting for opponent status to change.';
+    return room.players.filter((player) => player.playerId).length === 2 ? 'Game starts automatically when both players are ready.' : 'Waiting for opponent.';
   }
 
   private canStart(room: RoomRecord): boolean {
-    return (
-      !room.match &&
-      room.players.every(
-        (player) => player.playerId && player.connected && player.ready,
-      )
-    );
+    return !room.match && !room.disconnectWindow && room.players.every((player) => player.playerId && player.connected && player.ready);
   }
 
   private computePhase(room: RoomRecord): RoomPhase {
-    const occupiedCount = room.players.filter(
-      (player) => player.playerId,
-    ).length;
-    if (occupiedCount < 2) return "waiting-for-players";
-    return "lobby";
+    const occupiedCount = room.players.filter((player) => player.playerId).length;
+    if (occupiedCount < 2) return 'waiting-for-players';
+    return 'lobby';
   }
 
   private areBothPlayersPresent(room: RoomRecord): boolean {
-    return room.players.every(
-      (player) => player.playerId && player.connected && player.socketId,
-    );
+    return room.players.every((player) => player.playerId && player.connected && player.socketId);
   }
 
   private clearRematchState(room: RoomRecord) {
@@ -758,48 +797,65 @@ export class RoomService {
     room.rematch.requestedBySlot[1] = false;
   }
 
-  private getRoomForSocket(socketId: string): RoomRecord | undefined {
+  private error(socketId: string, reason: LobbyErrorReason): ClientEvent {
+    const messages: Record<LobbyErrorReason, string> = {
+      INVALID_ROOM_CODE: 'Enter a valid four-letter room code.',
+      ROOM_NOT_FOUND: 'Room not found.',
+      ROOM_FULL: 'Room is full right now.',
+      GAME_ALREADY_STARTED: 'This room is already mid-match.',
+      ACTION_NOT_ALLOWED: 'That action is not allowed right now.',
+    };
+    return { type: 'room:error', socketId, payload: { reason, message: messages[reason] } };
+  }
+
+  private resumeError(socketId: string, roomCode: string, reason: SessionResumeFailedPayload['reason'], message: string): ClientEvent {
+    return {
+      type: 'session:resume:failed',
+      socketId,
+      payload: { roomCode, reason, message } satisfies SessionResumeFailedPayload,
+    };
+  }
+
+  private buildSessionIssuedEvent(room: RoomRecord, slot: PlayerSlot, socketId: string, issuedAt: number): ClientEvent {
+    return {
+      type: 'session:issued',
+      socketId,
+      payload: {
+        roomCode: room.roomCode,
+        slotIndex: slot.slotIndex,
+        reconnectToken: slot.reconnectToken!,
+        issuedAt,
+        version: room.version,
+      } satisfies PlayerSessionPayload,
+    };
+  }
+
+  private generateReconnectToken() {
+    return randomBytes(18).toString('base64url');
+  }
+
+  private getRoomForSocket(socketId: string): RoomRecord | null {
     const roomCode = this.socketToRoom.get(socketId);
-    return roomCode ? this.rooms.get(roomCode) : undefined;
+    return roomCode ? this.rooms.get(roomCode) ?? null : null;
   }
 
-  private normalizeRoomCode(roomCode: string): string {
-    return roomCode.trim().toUpperCase();
+  private generateUniqueRoomCode() {
+    let roomCode = '';
+    do {
+      roomCode = Array.from({ length: 4 }, () => String.fromCharCode(65 + Math.floor(Math.random() * 26))).join('');
+    } while (this.rooms.has(roomCode));
+    return roomCode;
   }
 
-  private isValidRoomCode(roomCode: string): boolean {
-    return /^[A-Z]{4,6}$/.test(roomCode);
-  }
-
-  private allocatePlayerId(): string {
+  private allocatePlayerId() {
     return `player-${this.nextPlayerId++}`;
   }
 
-  private generateUniqueRoomCode(): string {
-    const letters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
-    let code = "";
-    do {
-      code = Array.from(
-        { length: 4 },
-        () => letters[Math.floor(Math.random() * letters.length)],
-      ).join("");
-    } while (this.rooms.has(code));
-    return code;
+  private normalizeRoomCode(roomCode: string) {
+    return roomCode.trim().toUpperCase();
   }
 
-  private error(socketId: string, reason: LobbyErrorReason): ClientEvent {
-    const messages: Record<LobbyErrorReason, string> = {
-      INVALID_ROOM_CODE: "Enter a valid room code.",
-      ROOM_NOT_FOUND: "Room no longer exists.",
-      ROOM_FULL: "That room is already full.",
-      GAME_ALREADY_STARTED: "That game has already started.",
-      ACTION_NOT_ALLOWED: "That action is not available right now.",
-    };
-
-    return {
-      type: "room:error",
-      socketId,
-      payload: { reason, message: messages[reason] },
-    };
+  private isValidRoomCode(roomCode: string) {
+    return /^[A-Z]{4}$/.test(roomCode);
   }
 }

--- a/src/server/roomService.ts
+++ b/src/server/roomService.ts
@@ -182,9 +182,6 @@ export class RoomService {
     const room = this.rooms.get(roomCode);
     if (!room) return { events: [this.error(socketId, 'ROOM_NOT_FOUND')] };
     if (room.phase === 'starting' || room.phase === 'in-progress') return { events: [this.error(socketId, 'GAME_ALREADY_STARTED')] };
-    if (room.phase === 'game-over' && room.players.every((player) => player.playerId)) {
-      return { events: [this.error(socketId, 'GAME_ALREADY_STARTED')] };
-    }
 
     const emptySlot = room.players.find((player) => !player.playerId);
     if (!emptySlot) return { events: [this.error(socketId, 'ROOM_FULL')] };

--- a/src/shared/contracts.ts
+++ b/src/shared/contracts.ts
@@ -3,6 +3,7 @@ export type Direction = 'up' | 'down' | 'left' | 'right';
 export type RoundResult = 'win' | 'lose' | 'draw';
 export type DeathReason = 'wall' | 'self' | 'head-to-head' | 'head-to-body' | 'cross-over' | 'disconnect';
 export type RematchStatus = 'unavailable' | 'idle' | 'waiting' | 'accepted';
+export type ReconnectStatus = 'none' | 'waiting-for-player' | 'resume-countdown';
 
 export type LobbyErrorReason =
   | 'INVALID_ROOM_CODE'
@@ -14,6 +15,17 @@ export type LobbyErrorReason =
 export interface GridPoint {
   x: number;
   y: number;
+}
+
+export interface ReconnectView {
+  active: boolean;
+  status: ReconnectStatus;
+  disconnectedSlotIndex: 0 | 1 | null;
+  reservedUntil: number | null;
+  secondsRemaining: number | null;
+  affectedPhase: RoomPhase | null;
+  yourSlotReserved: boolean;
+  canAutoResume: boolean;
 }
 
 export interface RematchView {
@@ -30,6 +42,8 @@ export interface LobbyPlayerView {
   slotIndex: 0 | 1;
   isOccupied: boolean;
   isReady: boolean;
+  isConnected: boolean;
+  isReserved: boolean;
   label: 'Player 1' | 'Player 2';
   isYou: boolean;
 }
@@ -37,6 +51,7 @@ export interface LobbyPlayerView {
 export interface LobbyStatePayload {
   roomCode: string;
   phase: RoomPhase;
+  yourSlotIndex: 0 | 1 | null;
   players: [LobbyPlayerView, LobbyPlayerView];
   occupiedCount: 0 | 1 | 2;
   allPlayersPresent: boolean;
@@ -45,6 +60,7 @@ export interface LobbyStatePayload {
   version: number;
   message?: string;
   rematch: RematchView;
+  reconnect: ReconnectView;
 }
 
 export interface PublicSnakeState {
@@ -58,6 +74,7 @@ export interface PublicSnakeState {
 export interface PublicGameStatePayload {
   roomCode: string;
   phase: 'starting' | 'in-progress' | 'game-over';
+  yourSlotIndex: 0 | 1 | null;
   tickNumber: number;
   board: {
     width: 30;
@@ -68,6 +85,8 @@ export interface PublicGameStatePayload {
   foodsEaten: number;
   tickIntervalMs: number;
   countdownSecondsRemaining?: 3 | 2 | 1 | 0;
+  paused?: boolean;
+  reconnect: ReconnectView;
   result?: {
     outcome: RoundResult;
     winnerSlotIndex: 0 | 1 | null;
@@ -75,6 +94,38 @@ export interface PublicGameStatePayload {
   };
   rematch: RematchView;
   version: number;
+}
+
+export interface PlayerSessionPayload {
+  roomCode: string;
+  slotIndex: 0 | 1;
+  reconnectToken: string;
+  issuedAt: number;
+  version: number;
+}
+
+export interface SessionResumeRequestPayload {
+  roomCode: string;
+  reconnectToken: string;
+}
+
+export interface SessionResumeSucceededPayload {
+  roomCode: string;
+  slotIndex: 0 | 1;
+  phase: RoomPhase;
+  resumedAt: number;
+  version: number;
+}
+
+export interface SessionResumeFailedPayload {
+  roomCode: string;
+  reason:
+    | 'ROOM_NOT_FOUND'
+    | 'RESERVATION_EXPIRED'
+    | 'TOKEN_MISMATCH'
+    | 'SLOT_NOT_RESERVED'
+    | 'SLOT_ALREADY_ACTIVE';
+  message: string;
 }
 
 export interface RoomCreatedPayload {
@@ -149,6 +200,8 @@ export interface GameRematchStatePayload {
   roomCode: string;
   phase: 'game-over' | 'waiting-for-players' | 'lobby' | 'starting';
   rematch: RematchView;
+  reconnect: ReconnectView;
+  yourSlotIndex: 0 | 1 | null;
   version: number;
   message?: string;
 }
@@ -176,4 +229,8 @@ export const EVENTS = {
   gameRematchRequest: 'game:rematch-request',
   gameRematchState: 'game:rematch-state',
   roomClosed: 'room:closed',
+  sessionIssued: 'session:issued',
+  sessionResume: 'session:resume',
+  sessionResumeSucceeded: 'session:resume:succeeded',
+  sessionResumeFailed: 'session:resume:failed',
 } as const;


### PR DESCRIPTION
Implements #63.\n\n- adds room-scoped reconnect tokens and session resume flow\n- reserves disconnected slots for 30s across lobby/game-over and pauses active matches\n- resumes paused matches with server-driven countdown or awards disconnect forfeit on timeout\n- updates UI and tests for reconnect state handling\n\nTests:\n- npm run build\n- npm test