### PR TITLE
test: add Playwright smoke E2E test

### DIFF
--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -1,0 +1,25 @@
+import { test, expect } from '@playwright/test';
+
+test('app loads and shows entry screen', async ({ page }) => {
+  await page.goto('/');
+
+  // Page title
+  await expect(page).toHaveTitle('Multiplayer Snake');
+
+  // Entry screen is visible with key UI
+  await expect(page.locator('#entry')).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Multiplayer Snake' })).toBeVisible();
+
+  // Player name input and room controls are present
+  await expect(page.locator('#playerNameInput')).toBeVisible();
+  await expect(page.locator('#createRoomButton')).toBeVisible();
+  await expect(page.locator('#joinRoomButton')).toBeVisible();
+  await expect(page.locator('#roomCodeInput')).toBeVisible();
+});
+
+test('socket.io connects and status updates', async ({ page }) => {
+  await page.goto('/');
+
+  // The #status element should transition from "Connecting…" to something else
+  await expect(page.locator('#status')).not.toHaveText('Connecting…', { timeout: 10_000 });
+});


### PR DESCRIPTION
## What
Adds a minimal Playwright smoke E2E test suite (tests/e2e/smoke.spec.ts) with 2 tests:

1. **Entry screen loads** — verifies page title, heading, player name input, create/join buttons, and room code input are all visible.
2. **Socket.IO connects** — verifies the status element transitions from "Connecting…" within 10 seconds.

## Why
Establishes a baseline E2E smoke test to catch regressions on the critical user path (page load + real-time connection).

## Test results
- `npm run test:e2e` → 2 passed in 39.1s (headless chromium)