### PR TITLE
feat: apply Snake Arena design system to production UI

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3,7 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
-    <title>Multiplayer Snake</title>
+    <title>Snake Arena</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Bungee&family=Space+Grotesk:wght@400;500;600;700&family=Space+Mono:wght@400;700&display=swap" rel="stylesheet" />
     <link rel="stylesheet" href="/styles.css" />
   </head>
   <body>
@@ -11,9 +14,9 @@
       <section class="panel phase-entry" data-phase="entry" data-outcome="neutral">
         <div id="panelTop" class="panel-top">
           <div>
-            <p class="kicker">Retro arcade multiplayer</p>
-            <h1>Multiplayer Snake</h1>
-            <p class="subtitle">Create a room, share the code, ready up, then survive the round.</p>
+            <p class="kicker">2-player arcade</p>
+            <h1>Snake Arena</h1>
+            <p class="subtitle">Create a room, share the code, and battle it out.</p>
           </div>
           <div class="topbar-actions">
             <button id="soundToggleButton" class="secondary-button sound-toggle" type="button" aria-pressed="false">Sound: on</button>
@@ -28,12 +31,12 @@
           <div class="hero-card">
             <div class="hero-copy">
               <div class="eyebrow">2-player showdown</div>
-              <h2>Clean boards. Neon tension. Quick rematches.</h2>
-              <p>Spin up a room in one tap or punch in a code to jump straight into the arena.</p>
+              <h2>Neon boards. Quick rounds. No mercy.</h2>
+              <p>Spin up a room or punch in a code to enter the arena.</p>
             </div>
             <div class="actions arcade-actions">
               <input id="playerNameInput" maxlength="24" placeholder="Your name" />
-              <p id="nameHelp" class="message">Enter a name up to 12 characters. Spaces are fine; emoji are not.</p>
+              <p id="nameHelp" class="message">Up to 24 characters. Spaces OK, emoji not.</p>
               <button id="createRoomButton" class="primary-button">Create versus room</button>
               <button id="createCoOpRoomButton" class="primary-button coop-button">Create co-op room</button>
               <button id="playSoloButton" class="primary-button solo-button">Play Solo</button>
@@ -77,7 +80,7 @@
               </div>
               <div id="rematchPanel" class="info-card rematch-card hidden">
                 <div class="eyebrow">Rematch</div>
-                <p id="rematchStatus" class="info-copy">Want another round? Accept rematch to stay in this room.</p>
+                <p id="rematchStatus" class="info-copy">Want another round? Accept to stay in this room.</p>
                 <button id="rematchButton" class="primary-button" type="button">Accept rematch</button>
               </div>
               <div id="scoreCard0" class="info-card compact-score-card player-card" data-player="0">
@@ -141,7 +144,7 @@
               </div>
             </aside>
           </div>
-          <p class="controls-hint">Swipe or tap the arrows on mobile. Arrow keys or WASD on desktop.</p>
+          <p class="controls-hint">Swipe or tap arrows on mobile. Arrow keys or WASD on desktop.</p>
         </section>
       </section>
     </main>

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,31 +1,59 @@
+/* ═══ Snake Arena Design System ═══
+   Palette: Deep navy / arcade-cabinet
+   P1 blue #2E8BFF, P2 orange #FF7A1A, bg #0A0E1A
+   Typography: Bungee (display), Space Grotesk (body), Space Mono (mono)
+   UI: Raised/inset panels, small radii, crisp borders, arcade microcopy
+*/
+
 :root {
   color-scheme: dark;
-  font-family: Inter, "Segoe UI", system-ui, sans-serif;
-  --bg-app: radial-gradient(circle at top, #182643 0%, #0a0f1d 52%, #05070f 100%);
-  --bg-panel: linear-gradient(180deg, rgba(16, 25, 45, 0.96), rgba(6, 10, 21, 0.98));
+  font-family: 'Space Grotesk', 'Segoe UI', system-ui, sans-serif;
+  /* ── Typography ── */
+  --font-display: 'Bungee', 'Impact', sans-serif;
+  --font-body: 'Space Grotesk', 'Segoe UI', system-ui, sans-serif;
+  --font-mono: 'Space Mono', 'SF Mono', 'Consolas', monospace;
+  /* ── Backgrounds ── */
+  --bg-app: #0A0E1A;
+  --bg-panel: linear-gradient(180deg, rgba(10, 14, 26, 0.96), rgba(6, 10, 21, 0.98));
   --bg-card: rgba(9, 16, 31, 0.9);
   --bg-card-strong: rgba(13, 20, 39, 0.98);
   --bg-board: #09111f;
   --bg-cell: #0d1728;
-  --text-primary: #f8fbff;
+  /* ── Text ── */
+  --text-primary: #f0f4ff;
   --text-muted: #9eb1d1;
   --text-dim: #7083a5;
-  --accent-primary: #7cff6b;
-  --accent-secondary: #49d7ff;
+  /* ── Player identity ── */
+  --p1-blue: #2E8BFF;
+  --p1-blue-light: #5aa8ff;
+  --p1-blue-glow: rgba(46, 139, 255, 0.35);
+  --p2-orange: #FF7A1A;
+  --p2-orange-light: #ffa24c;
+  --p2-orange-glow: rgba(255, 122, 26, 0.35);
+  /* ── Accent palette ── */
+  --accent-primary: #2E8BFF;
+  --accent-secondary: #FF7A1A;
+  --accent-cyan: #49d7ff;
+  --accent-magenta: #ff5d7a;
+  --accent-yellow: #ffd166;
   --accent-danger: #ff5d7a;
   --accent-warning: #ffd166;
   --accent-success: #87ffb5;
-  --border-subtle: rgba(126, 156, 214, 0.2);
-  --border-strong: rgba(124, 255, 107, 0.38);
-  --glow-primary: 0 0 0 1px rgba(124, 255, 107, 0.25), 0 0 24px rgba(124, 255, 107, 0.2);
-  --glow-secondary: 0 0 0 1px rgba(73, 215, 255, 0.25), 0 0 24px rgba(73, 215, 255, 0.2);
+  /* ── Borders ── */
+  --border-subtle: rgba(46, 139, 255, 0.18);
+  --border-strong: rgba(46, 139, 255, 0.38);
+  /* ── Glows ── */
+  --glow-primary: 0 0 0 1px rgba(46, 139, 255, 0.25), 0 0 24px rgba(46, 139, 255, 0.2);
+  --glow-secondary: 0 0 0 1px rgba(255, 122, 26, 0.25), 0 0 24px rgba(255, 122, 26, 0.2);
   --glow-danger: 0 0 0 1px rgba(255, 93, 122, 0.28), 0 0 28px rgba(255, 93, 122, 0.22);
   --shadow-panel: 0 28px 80px rgba(0, 0, 0, 0.48);
-  --radius-lg: 24px;
-  --radius-md: 18px;
-  --radius-sm: 12px;
+  /* ── Layout ── */
+  --radius-lg: 16px;
+  --radius-md: 12px;
+  --radius-sm: 8px;
   --app-padding: 14px;
   --panel-padding: 18px;
+  /* ── Motion ── */
   --motion-fast: 140ms;
   --motion-base: 220ms;
   --motion-slow: 420ms;
@@ -33,7 +61,12 @@
 }
 
 * { box-sizing: border-box; }
-body { margin: 0; background: var(--bg-app); color: var(--text-primary); }
+body {
+  margin: 0;
+  background: var(--bg-app);
+  color: var(--text-primary);
+  font-family: var(--font-body);
+}
 button, input { font: inherit; }
 button { cursor: pointer; }
 body::before {
@@ -42,9 +75,9 @@ body::before {
   inset: 0;
   pointer-events: none;
   background:
-    linear-gradient(rgba(255,255,255,0.03), rgba(255,255,255,0)) 0 0 / 100% 100%,
-    repeating-linear-gradient(180deg, rgba(255,255,255,0.025) 0, rgba(255,255,255,0.025) 1px, transparent 1px, transparent 4px);
-  opacity: 0.22;
+    linear-gradient(rgba(255,255,255,0.02), rgba(255,255,255,0)) 0 0 / 100% 100%,
+    repeating-linear-gradient(180deg, rgba(255,255,255,0.018) 0, rgba(255,255,255,0.018) 1px, transparent 1px, transparent 4px);
+  opacity: 0.18;
 }
 .app {
   min-height: 100vh;
@@ -67,7 +100,7 @@ body::before {
   content: "";
   position: absolute;
   inset: 0;
-  background: linear-gradient(135deg, rgba(124, 255, 107, 0.06), transparent 30%, rgba(73, 215, 255, 0.08) 100%);
+  background: linear-gradient(135deg, rgba(46, 139, 255, 0.05), transparent 30%, rgba(255, 122, 26, 0.06) 100%);
   pointer-events: none;
 }
 .panel.gameplay-active {
@@ -84,12 +117,23 @@ body::before {
 }
 .topbar-actions { align-items: center; flex-wrap: wrap; }
 h1, h2, p { margin-top: 0; }
-h1 { margin-bottom: 8px; font-size: clamp(2rem, 4vw, 3rem); }
+h1 {
+  margin-bottom: 8px;
+  font-size: clamp(2rem, 4vw, 3rem);
+  font-family: var(--font-display);
+  letter-spacing: 0.04em;
+}
+h2 {
+  font-family: var(--font-display);
+  letter-spacing: 0.03em;
+}
 .kicker, .eyebrow {
   color: var(--text-dim);
   text-transform: uppercase;
   letter-spacing: 0.18em;
   font-size: 0.75rem;
+  font-family: var(--font-mono);
+  font-weight: 700;
 }
 .subtitle, .message, .controls-hint, .info-copy, .game-meta-stack, .player-meta span, .player-state {
   color: var(--text-muted);
@@ -97,12 +141,14 @@ h1 { margin-bottom: 8px; font-size: clamp(2rem, 4vw, 3rem); }
 .status, .error, .badge {
   margin: 14px 0 0;
   padding: 12px 14px;
-  border-radius: 14px;
+  border-radius: var(--radius-md);
   border: 1px solid transparent;
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
 }
 .status {
-  background: rgba(73, 215, 255, 0.12);
-  border-color: rgba(73, 215, 255, 0.24);
+  background: rgba(46, 139, 255, 0.10);
+  border-color: rgba(46, 139, 255, 0.24);
 }
 .error {
   background: rgba(255, 93, 122, 0.14);
@@ -121,8 +167,8 @@ h1 { margin-bottom: 8px; font-size: clamp(2rem, 4vw, 3rem); }
   gap: 18px;
   padding: 22px;
   background:
-    radial-gradient(circle at top right, rgba(73, 215, 255, 0.16), transparent 26%),
-    radial-gradient(circle at bottom left, rgba(124, 255, 107, 0.14), transparent 30%),
+    radial-gradient(circle at top right, rgba(255, 122, 26, 0.12), transparent 26%),
+    radial-gradient(circle at bottom left, rgba(46, 139, 255, 0.10), transparent 30%),
     var(--bg-card-strong);
 }
 .hero-copy h2 { font-size: clamp(1.4rem, 3vw, 2.4rem); margin-bottom: 12px; }
@@ -133,8 +179,8 @@ h1 { margin-bottom: 8px; font-size: clamp(2rem, 4vw, 3rem); }
 .arcade-actions { gap: 14px; }
 .join-row { display: flex; gap: 10px; }
 input, button {
-  border-radius: 14px;
-  border: 1px solid rgba(126, 156, 214, 0.28);
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(46, 139, 255, 0.22);
   padding: 12px 14px;
   transition: transform var(--motion-fast) var(--ease-arcade), box-shadow var(--motion-fast) var(--ease-arcade), border-color var(--motion-fast) var(--ease-arcade), background var(--motion-fast) var(--ease-arcade), color var(--motion-fast) var(--ease-arcade), opacity var(--motion-fast) var(--ease-arcade);
 }
@@ -143,21 +189,28 @@ input {
   background: rgba(5, 10, 20, 0.92);
   color: var(--text-primary);
   text-transform: uppercase;
-  box-shadow: inset 0 0 0 1px rgba(73, 215, 255, 0.06);
+  font-family: var(--font-mono);
+  letter-spacing: 0.08em;
+  box-shadow: inset 0 0 0 1px rgba(46, 139, 255, 0.06);
+}
+input::placeholder {
+  color: var(--text-dim);
+  opacity: 0.7;
 }
 input:focus-visible, button:focus-visible {
   outline: none;
-  border-color: rgba(73, 215, 255, 0.72);
+  border-color: rgba(255, 122, 26, 0.72);
   box-shadow: var(--glow-secondary);
 }
 button:hover:not(:disabled) { transform: translateY(-1px); }
 button:active:not(:disabled) { transform: translateY(0); }
 button:disabled { cursor: not-allowed; opacity: 0.58; }
 .primary-button {
-  background: linear-gradient(135deg, var(--accent-primary), #27d38a);
-  color: #04140a;
+  background: linear-gradient(135deg, var(--accent-primary), #1a6fe6);
+  color: #fff;
   font-weight: 800;
-  box-shadow: 0 12px 24px rgba(39, 211, 138, 0.18);
+  box-shadow: 0 12px 24px rgba(46, 139, 255, 0.18);
+  letter-spacing: 0.04em;
 }
 .secondary-button, .sound-toggle {
   background: rgba(7, 14, 28, 0.92);
@@ -173,35 +226,36 @@ button:disabled { cursor: not-allowed; opacity: 0.58; }
   box-shadow: 0 12px 24px rgba(99, 102, 241, 0.18);
 }
 .coop-button {
-  background: linear-gradient(135deg, #49d7ff, #7cff6b);
-  color: #041521;
+  background: linear-gradient(135deg, var(--accent-cyan), var(--accent-primary));
+  color: #fff;
   box-shadow: 0 12px 24px rgba(73, 215, 255, 0.18);
 }
 .room-code-hero {
   padding: 18px;
-  border: 1px solid rgba(124, 255, 107, 0.22);
+  border: 1px solid rgba(46, 139, 255, 0.22);
   border-radius: var(--radius-md);
-  background: linear-gradient(135deg, rgba(124, 255, 107, 0.1), rgba(73, 215, 255, 0.08));
+  background: linear-gradient(135deg, rgba(46, 139, 255, 0.08), rgba(255, 122, 26, 0.06));
   box-shadow: var(--glow-primary);
 }
 .room-code, .game-room-code {
   font-size: clamp(1.8rem, 5vw, 3rem);
   font-weight: 900;
   letter-spacing: 0.18em;
+  font-family: var(--font-mono);
 }
 .game-room-code { font-size: clamp(1.5rem, 3vw, 2.2rem); }
 .badge, .player-chip {
   width: fit-content;
   text-transform: capitalize;
-  background: rgba(73, 215, 255, 0.12);
-  border: 1px solid rgba(73, 215, 255, 0.22);
+  background: rgba(46, 139, 255, 0.10);
+  border: 1px solid rgba(46, 139, 255, 0.22);
 }
 .player {
   padding: 16px;
   background: rgba(10, 18, 34, 0.9);
 }
-.player.you { border-color: rgba(124, 255, 107, 0.44); box-shadow: var(--glow-primary); }
-.player.ready { border-color: rgba(124, 255, 107, 0.32); }
+.player.you { border-color: rgba(46, 139, 255, 0.44); box-shadow: var(--glow-primary); }
+.player.ready { border-color: rgba(46, 139, 255, 0.32); }
 .player.waiting { opacity: 0.72; }
 .player-state { margin-top: 8px; }
 .ready-button { min-height: 54px; }
@@ -223,10 +277,15 @@ button:disabled { cursor: not-allowed; opacity: 0.58; }
 }
 .info-card { padding: 14px; background: rgba(7, 13, 24, 0.92); }
 .gameplay-summary-card { min-height: 128px; }
-.game-phase { font-size: clamp(1.5rem, 2vw, 2rem); font-weight: 800; }
+.game-phase {
+  font-size: clamp(1.5rem, 2vw, 2rem);
+  font-weight: 800;
+  font-family: var(--font-display);
+  letter-spacing: 0.04em;
+}
 .player-card { position: relative; overflow: hidden; }
-.player-card[data-player="0"] { border-color: rgba(124, 255, 107, 0.32); }
-.player-card[data-player="1"] { border-color: rgba(73, 215, 255, 0.32); }
+.player-card[data-player="0"] { border-color: var(--p1-blue-glow); border-left: 3px solid var(--p1-blue); }
+.player-card[data-player="1"] { border-color: var(--p2-orange-glow); border-left: 3px solid var(--p2-orange); }
 .player-card.is-you::after {
   content: "YOU";
   position: absolute;
@@ -236,6 +295,7 @@ button:disabled { cursor: not-allowed; opacity: 0.58; }
   font-weight: 800;
   letter-spacing: 0.12em;
   color: var(--text-dim);
+  font-family: var(--font-mono);
 }
 .player-card.is-leading { box-shadow: var(--glow-primary); }
 .player-card.is-eliminated { opacity: 0.72; }
@@ -249,18 +309,28 @@ button:disabled { cursor: not-allowed; opacity: 0.58; }
   min-height: 104px;
   align-content: center;
 }
-.score-card strong { font-size: clamp(2rem, 3vw, 2.6rem); line-height: 1; }
-.player-one { border-color: rgba(124, 255, 107, 0.4); }
-.player-two { border-color: rgba(73, 215, 255, 0.4); }
+.score-card span {
+  font-family: var(--font-mono);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  font-size: 0.7rem;
+}
+.score-card strong {
+  font-size: clamp(2rem, 3vw, 2.6rem);
+  line-height: 1;
+  font-family: var(--font-mono);
+}
+.player-one { border-color: var(--p1-blue-glow); background: linear-gradient(135deg, rgba(46, 139, 255, 0.08), rgba(9, 17, 31, 0.95)); }
+.player-two { border-color: var(--p2-orange-glow); background: linear-gradient(135deg, rgba(255, 122, 26, 0.08), rgba(9, 17, 31, 0.95)); }
 .score-card.score-pop { animation: scorePop 420ms var(--ease-arcade); }
 .game-stage {
   width: min(100%, 760px);
   aspect-ratio: 1;
   position: relative;
-  border-radius: 24px;
+  border-radius: var(--radius-lg);
   padding: 12px;
   background: linear-gradient(180deg, rgba(12, 21, 39, 0.98), rgba(5, 10, 20, 0.98));
-  border: 1px solid rgba(126, 156, 214, 0.28);
+  border: 1px solid rgba(46, 139, 255, 0.20);
   box-shadow: 0 22px 42px rgba(0, 0, 0, 0.28), inset 0 0 0 1px rgba(255, 255, 255, 0.02);
   overflow: hidden;
 }
@@ -268,13 +338,13 @@ button:disabled { cursor: not-allowed; opacity: 0.58; }
   content: "";
   position: absolute;
   inset: 0;
-  background: radial-gradient(circle at center, transparent 45%, rgba(73, 215, 255, 0.06) 100%);
+  background: radial-gradient(circle at center, transparent 45%, rgba(46, 139, 255, 0.05) 100%);
   pointer-events: none;
 }
 .board-fx-layer, .countdown-overlay {
   position: absolute;
   inset: 12px;
-  border-radius: 18px;
+  border-radius: 12px;
   pointer-events: none;
 }
 .board-fx-layer { opacity: 0; }
@@ -287,9 +357,9 @@ button:disabled { cursor: not-allowed; opacity: 0.58; }
   display: grid;
   grid-template-columns: repeat(30, minmax(0, 1fr));
   gap: 1px;
-  background: rgba(70, 90, 120, 0.42);
-  border: 1px solid rgba(108, 133, 175, 0.32);
-  border-radius: 18px;
+  background: rgba(46, 139, 255, 0.22);
+  border: 1px solid rgba(46, 139, 255, 0.28);
+  border-radius: 12px;
   padding: 1px;
   width: 100%;
   height: 100%;
@@ -307,7 +377,7 @@ button:disabled { cursor: not-allowed; opacity: 0.58; }
   box-shadow: 0 0 12px rgba(245, 158, 11, 0.42);
 }
 .cell.exit.exit-ready {
-  box-shadow: 0 0 14px rgba(124, 255, 107, 0.45), inset 0 0 0 2px rgba(255,255,255,0.38);
+  box-shadow: 0 0 14px rgba(46, 139, 255, 0.45), inset 0 0 0 2px rgba(255,255,255,0.38);
 }
 .cell.food {
   background: radial-gradient(circle, #fff2b3 0%, var(--accent-warning) 42%, #ff7b54 100%);
@@ -315,12 +385,12 @@ button:disabled { cursor: not-allowed; opacity: 0.58; }
 }
 .cell.food:not(.reduce-motion) { animation: foodPulse 1000ms ease-in-out infinite; }
 .cell.snake-0 {
-  background: linear-gradient(180deg, #8dff72, #34d87f);
-  box-shadow: inset 0 0 0 1px rgba(255,255,255,0.08);
+  background: linear-gradient(180deg, var(--p1-blue-light), var(--p1-blue));
+  box-shadow: inset 0 0 0 1px rgba(255,255,255,0.10);
 }
 .cell.snake-1 {
-  background: linear-gradient(180deg, #89ebff, #3fb8ff);
-  box-shadow: inset 0 0 0 1px rgba(255,255,255,0.08);
+  background: linear-gradient(180deg, var(--p2-orange-light), var(--p2-orange));
+  box-shadow: inset 0 0 0 1px rgba(255,255,255,0.10);
 }
 .cell.head { box-shadow: inset 0 0 0 2px rgba(255,255,255,.38), 0 0 12px rgba(255,255,255,0.14); }
 .countdown-overlay {
@@ -332,8 +402,9 @@ button:disabled { cursor: not-allowed; opacity: 0.58; }
   letter-spacing: 0.08em;
   text-transform: uppercase;
   color: var(--text-primary);
-  background: radial-gradient(circle at center, rgba(124, 255, 107, 0.12), rgba(73, 215, 255, 0.04) 45%, transparent 72%);
-  text-shadow: 0 0 18px rgba(124, 255, 107, 0.38), 0 0 48px rgba(73, 215, 255, 0.28);
+  font-family: var(--font-display);
+  background: radial-gradient(circle at center, rgba(46, 139, 255, 0.12), rgba(255, 122, 26, 0.04) 45%, transparent 72%);
+  text-shadow: 0 0 18px rgba(46, 139, 255, 0.38), 0 0 48px rgba(255, 122, 26, 0.28);
 }
 .countdown-overlay[data-countdown-value='GO'] {
   color: #fff2b3;
@@ -375,7 +446,6 @@ body.swipe-active {
 }
 body.swipe-active button,
 body.swipe-active input {
-  /* Restore tap/click on interactive elements while the page is scroll-locked. */
   touch-action: manipulation;
   -ms-touch-action: manipulation;
 }
@@ -405,10 +475,10 @@ body.swipe-active input {
   opacity: 1;
   transform: translate(-50%, -50%) scale(1);
 }
-.swipe-trail[data-direction="up"] { box-shadow: 0 -8px 16px rgba(73, 215, 255, 0.35); }
-.swipe-trail[data-direction="down"] { box-shadow: 0 8px 16px rgba(73, 215, 255, 0.35); }
-.swipe-trail[data-direction="left"] { box-shadow: -8px 0 16px rgba(73, 215, 255, 0.35); }
-.swipe-trail[data-direction="right"] { box-shadow: 8px 0 16px rgba(73, 215, 255, 0.35); }
+.swipe-trail[data-direction="up"] { box-shadow: 0 -8px 16px var(--p2-orange-glow); }
+.swipe-trail[data-direction="down"] { box-shadow: 0 8px 16px var(--p2-orange-glow); }
+.swipe-trail[data-direction="left"] { box-shadow: -8px 0 16px var(--p2-orange-glow); }
+.swipe-trail[data-direction="right"] { box-shadow: 8px 0 16px var(--p2-orange-glow); }
 .touch-control-up {
   width: min(44%, 140px);
 }
@@ -425,12 +495,13 @@ body.swipe-active input {
 .build-marker, .inline-build-marker {
   padding: 8px 10px;
   border-radius: 999px;
-  border: 1px solid rgba(126, 156, 214, 0.2);
+  border: 1px solid rgba(46, 139, 255, 0.15);
   background: rgba(5, 10, 20, 0.88);
   color: var(--text-muted);
   font-size: 12px;
   line-height: 1.2;
   letter-spacing: 0.02em;
+  font-family: var(--font-mono);
 }
 .rematch-card.highlighted { box-shadow: var(--glow-primary); }
 .post-game-banner {
@@ -443,12 +514,16 @@ body.swipe-active input {
   display: grid;
   gap: 12px;
   transform: translateX(-50%);
-  background: linear-gradient(135deg, rgba(124, 255, 107, 0.16), rgba(10, 18, 34, 0.96) 40%, rgba(73, 215, 255, 0.14));
+  background: linear-gradient(135deg, rgba(46, 139, 255, 0.16), rgba(10, 18, 34, 0.96) 40%, rgba(255, 122, 26, 0.14));
   box-shadow: 0 18px 40px rgba(0, 0, 0, 0.34);
 }
 .panel[data-outcome="lose"] .post-game-banner { background: linear-gradient(135deg, rgba(255, 93, 122, 0.18), rgba(10, 18, 34, 0.96)); }
-.panel[data-outcome="draw"] .post-game-banner { background: linear-gradient(135deg, rgba(73, 215, 255, 0.18), rgba(10, 18, 34, 0.96)); }
-.post-game-title { font-size: clamp(1.9rem, 4vw, 3rem); margin-bottom: 0; }
+.panel[data-outcome="draw"] .post-game-banner { background: linear-gradient(135deg, rgba(255, 122, 26, 0.18), rgba(10, 18, 34, 0.96)); }
+.post-game-title {
+  font-size: clamp(1.9rem, 4vw, 3rem);
+  margin-bottom: 0;
+  font-family: var(--font-display);
+}
 .post-game-copy { margin-bottom: 0; }
 .post-game-button { width: 100%; min-height: 56px; font-size: 1rem; }
 .controls-hint { margin: 6px 0 0; text-align: center; }
@@ -521,10 +596,10 @@ body.swipe-active input {
 .panel[data-layout-mode^="mobile"] .score-card { min-height: auto; }
 .panel[data-layout-mode^="mobile"] .game-message { max-width: 100%; font-size: 0.95rem; }
 .panel[data-layout-mode^="mobile"] .touch-controls { width: min(100%, 360px); }
-.panel.phase-countdown .game-stage { box-shadow: 0 0 0 1px rgba(124, 255, 107, 0.22), 0 22px 42px rgba(0,0,0,0.28), 0 0 52px rgba(124,255,107,0.12); }
-.panel.phase-result[data-outcome="win"] .game-stage { box-shadow: 0 0 0 1px rgba(124,255,107,0.24), 0 22px 42px rgba(0,0,0,0.28), 0 0 46px rgba(124,255,107,0.12); }
+.panel.phase-countdown .game-stage { box-shadow: 0 0 0 1px rgba(46,139,255,0.22), 0 22px 42px rgba(0,0,0,0.28), 0 0 52px rgba(46,139,255,0.12); }
+.panel.phase-result[data-outcome="win"] .game-stage { box-shadow: 0 0 0 1px rgba(46,139,255,0.24), 0 22px 42px rgba(0,0,0,0.28), 0 0 46px rgba(46,139,255,0.12); }
 .panel.phase-result[data-outcome="lose"] .game-stage { box-shadow: 0 0 0 1px rgba(255,93,122,0.24), 0 22px 42px rgba(0,0,0,0.28), 0 0 42px rgba(255,93,122,0.10); }
-.panel.phase-result[data-outcome="draw"] .game-stage { box-shadow: 0 0 0 1px rgba(73,215,255,0.24), 0 22px 42px rgba(0,0,0,0.28), 0 0 42px rgba(73,215,255,0.10); }
+.panel.phase-result[data-outcome="draw"] .game-stage { box-shadow: 0 0 0 1px rgba(255,122,26,0.24), 0 22px 42px rgba(0,0,0,0.28), 0 0 42px rgba(255,122,26,0.10); }
 .sound-toggle.is-confirmed, .secondary-button.is-confirmed { box-shadow: var(--glow-secondary); }
 
 @keyframes countdownPulse {
@@ -545,13 +620,13 @@ body.swipe-active input {
 }
 @keyframes boardFlashWin {
   0% { opacity: 0; background: transparent; }
-  25% { opacity: 1; background: radial-gradient(circle at center, rgba(124,255,107,0.3), rgba(73,215,255,0.2)); }
+  25% { opacity: 1; background: radial-gradient(circle at center, rgba(46,139,255,0.3), rgba(255,122,26,0.2)); }
   100% { opacity: 0; background: transparent; }
 }
 @keyframes boardFlashDraw {
   0% { opacity: 0; background: transparent; }
-  25% { opacity: 1; background: rgba(73, 215, 255, 0.28); }
-  100% { opacity: 0; background: transparent; }
+  25% { opacity: 1; background: rgba(255, 122, 26, 0.28); }
+  100% { opacity: 0; background: rgba(255, 122, 26, 0); }
 }
 @keyframes foodPulse {
   0%, 100% { transform: scale(1); filter: brightness(1); }
@@ -793,7 +868,7 @@ body.mobile-fullscreen .mobile-hud {
   justify-content: space-between;
   align-items: center;
   padding: 6px 12px;
-  background: linear-gradient(180deg, rgba(5, 10, 20, 0.92) 0%, rgba(5, 10, 20, 0.6) 80%, transparent 100%);
+  background: linear-gradient(180deg, rgba(10, 14, 26, 0.94) 0%, rgba(10, 14, 26, 0.6) 80%, transparent 100%);
   pointer-events: none;
   min-height: 44px;
 }
@@ -801,7 +876,8 @@ body.mobile-fullscreen .mobile-hud {
   font-size: 1rem;
   font-weight: 800;
   color: var(--accent-primary);
-  text-shadow: 0 0 8px rgba(124, 255, 107, 0.3);
+  text-shadow: 0 0 8px var(--p1-blue-glow);
+  font-family: var(--font-mono);
 }
 .mobile-hud-room {
   font-size: 0.8rem;
@@ -810,6 +886,7 @@ body.mobile-fullscreen .mobile-hud {
   color: var(--text-muted);
   text-transform: uppercase;
   opacity: 0.8;
+  font-family: var(--font-mono);
 }
 .mobile-hud-phase {
   font-size: 0.75rem;
@@ -817,6 +894,7 @@ body.mobile-fullscreen .mobile-hud {
   color: var(--text-dim);
   text-transform: uppercase;
   letter-spacing: 0.1em;
+  font-family: var(--font-mono);
 }
 body.mobile-fullscreen .game-stage {
   margin-top: 44px;

--- a/tests/e2e/design-system.spec.ts
+++ b/tests/e2e/design-system.spec.ts
@@ -85,6 +85,8 @@ test.describe('Design system tokens', () => {
     });
 
     // Primary button background should reference the blue primary
-    expect(btnBg).toContain('2E8BFF');
+    // getComputedStyle returns rgb() values, not hex — check for rgb(46, 139, 255)
+    // which is the decimal equivalent of #2E8BFF
+    expect(btnBg).toContain('46, 139, 255');
   });
 });

--- a/tests/e2e/design-system.spec.ts
+++ b/tests/e2e/design-system.spec.ts
@@ -1,0 +1,90 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Design system tokens', () => {
+  test('landing page loads design tokens and typography', async ({ page }) => {
+    await page.goto('/');
+
+    // Wait for entry screen
+    await expect(page.locator('#entry')).toBeVisible();
+
+    // Verify CSS custom properties are applied on :root
+    const rootStyles = await page.evaluate(() => {
+      const root = document.documentElement;
+      const cs = getComputedStyle(root);
+      return {
+        p1Blue: cs.getPropertyValue('--p1-blue').trim(),
+        p2Orange: cs.getPropertyValue('--p2-orange').trim(),
+        bgApp: cs.getPropertyValue('--bg-app').trim(),
+        fontDisplay: cs.getPropertyValue('--font-display').trim(),
+        fontBody: cs.getPropertyValue('--font-body').trim(),
+        fontMono: cs.getPropertyValue('--font-mono').trim(),
+      };
+    });
+
+    // P1 blue and P2 orange tokens exist
+    expect(rootStyles.p1Blue).toBe('#2E8BFF');
+    expect(rootStyles.p2Orange).toBe('#FF7A1A');
+    expect(rootStyles.bgApp).toBe('#0A0E1A');
+
+    // Font stacks reference the design system fonts
+    expect(rootStyles.fontDisplay).toContain('Bungee');
+    expect(rootStyles.fontBody).toContain('Space Grotesk');
+    expect(rootStyles.fontMono).toContain('Space Mono');
+  });
+
+  test('h1 uses Bungee display font', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.locator('#entry')).toBeVisible();
+
+    const h1Font = await page.evaluate(() => {
+      const h1 = document.querySelector('h1');
+      return h1 ? getComputedStyle(h1).fontFamily : '';
+    });
+
+    expect(h1Font).toContain('Bungee');
+  });
+
+  test('eyebrow elements use Space Mono monospace font', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.locator('#entry')).toBeVisible();
+
+    const eyebrowFont = await page.evaluate(() => {
+      const eyebrow = document.querySelector('.eyebrow');
+      return eyebrow ? getComputedStyle(eyebrow).fontFamily : '';
+    });
+
+    expect(eyebrowFont).toContain('Space Mono');
+  });
+
+  test('player identity colors are blue/orange, not green/cyan', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.locator('#entry')).toBeVisible();
+
+    const colors = await page.evaluate(() => {
+      const root = document.documentElement;
+      const cs = getComputedStyle(root);
+      return {
+        accentPrimary: cs.getPropertyValue('--accent-primary').trim(),
+        accentSecondary: cs.getPropertyValue('--accent-secondary').trim(),
+      };
+    });
+
+    // Primary accent is blue, not green
+    expect(colors.accentPrimary).toBe('#2E8BFF');
+    // Secondary accent is orange, not cyan
+    expect(colors.accentSecondary).toBe('#FF7A1A');
+  });
+
+  test('primary button uses blue gradient', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.locator('#entry')).toBeVisible();
+
+    const btnBg = await page.evaluate(() => {
+      const btn = document.querySelector('.primary-button');
+      return btn ? getComputedStyle(btn).backgroundImage : '';
+    });
+
+    // Primary button background should reference the blue primary
+    expect(btnBg).toContain('2E8BFF');
+  });
+});

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -4,11 +4,11 @@ test('app loads and shows entry screen', async ({ page }) => {
   await page.goto('/');
 
   // Page title
-  await expect(page).toHaveTitle('Multiplayer Snake');
+  await expect(page).toHaveTitle('Snake Arena');
 
   // Entry screen is visible with key UI
   await expect(page.locator('#entry')).toBeVisible();
-  await expect(page.getByRole('heading', { name: 'Multiplayer Snake' })).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Snake Arena' })).toBeVisible();
 
   // Player name input and room controls are present
   await expect(page.locator('#playerNameInput')).toBeVisible();


### PR DESCRIPTION
Fixes #149.

## Summary
- Adds the Snake Arena design token layer (deep navy, P1 blue, P2 orange, Bungee / Space Grotesk / Space Mono) via CSS variables.
- Updates landing, lobby, match HUD, game-over/rematch, and mobile controls to use the new visual identity.
- Adds/updates Playwright coverage for design tokens, typography, P1/P2 identity colors, primary button gradient, and the entry-screen title.

## Scope
- `public/index.html`
- `public/styles.css`
- `tests/e2e/design-system.spec.ts`
- `tests/e2e/smoke.spec.ts`

## Out of scope
- No gameplay rule changes
- No server protocol changes
- No React rewrite

## Verification
- `npm test` — 30/30 passed
- `npm run build` — tsc clean
- `E2E_BASE_URL=http://127.0.0.1:31049 npm run test:e2e` — 7/7 passed
- `npm test -- src/server/__tests__/gameLogic.test.ts` — 10/10 passed (issue #150 co-op wall regression)
- Manual two-client Playwright visual smoke: landing → lobby → match → game-over on desktop and 375x812 mobile; screenshots captured in `test-results/issue149-manual-visual`

## Notes
- UI/CSS/HTML + E2E only; no server protocol or gameplay logic changes.
- Google Fonts are linked with system fallbacks.
