### PR TITLE
feat: lobby clarity / polish (issue #99)

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -611,19 +611,19 @@ function renderLobby(state) {
   const bothPresent = state.allPlayersPresent;
 
   if (!opponentPresent) {
-    nextActionIcon.textContent = '&#x1F4E3;';
+    nextActionIcon.textContent = String.fromCodePoint(0x1F4E3); // 📣 megaphone
     nextActionText.textContent = 'Share the room code above and wait for your opponent to join.';
   } else if (you && !you.isReady && opponent && !opponent.isReady) {
-    nextActionIcon.textContent = '&#x1F3C1;';
+    nextActionIcon.textContent = String.fromCodePoint(0x1F3C1); // 🏁 checkered flag
     nextActionText.textContent = 'Both players are here! Hit "Ready" when you\'re set to go.';
   } else if (you && !you.isReady) {
-    nextActionIcon.textContent = '&#x1F3C1;';
+    nextActionIcon.textContent = String.fromCodePoint(0x1F3C1); // 🏁 checkered flag
     nextActionText.textContent = 'Your opponent is ready. Hit "Ready" to start the match!';
   } else if (you && you.isReady && opponent && !opponent.isReady) {
-    nextActionIcon.textContent = '&#x23F3;';
+    nextActionIcon.textContent = String.fromCodePoint(0x23F3); // ⏳ hourglass
     nextActionText.textContent = 'You\'re ready! Waiting for your opponent to ready up.';
   } else if (bothReady) {
-    nextActionIcon.textContent = '&#x1F680;';
+    nextActionIcon.textContent = String.fromCodePoint(0x1F680); // 🚀 rocket
     nextActionText.textContent = 'Both ready — launching into the arena!';
   }
 

--- a/public/app.js
+++ b/public/app.js
@@ -48,6 +48,10 @@ const touchControlsEl = document.getElementById('touchControls');
 const swipeTrailEl = document.getElementById('swipeTrail');
 const touchControlButtons = Array.from(document.querySelectorAll('[data-direction]'));
 const mobileHudEl = document.getElementById('mobileHud');
+const nextActionArea = document.getElementById('nextActionArea');
+const nextActionIcon = document.getElementById('nextActionIcon');
+const nextActionText = document.getElementById('nextActionText');
+const bothReadyIndicator = document.getElementById('bothReadyIndicator');
 const mobileHudScoreEl = document.getElementById('mobileHudScore');
 const mobileHudPhaseEl = document.getElementById('mobileHudPhase');
 const mobileHudRoomEl = document.getElementById('mobileHudRoom');
@@ -575,19 +579,63 @@ function renderLobby(state) {
   showScreen(gameplayFocused ? 'gameplay' : 'lobby');
 
   for (const player of state.players) {
+    const slotClass = player.slotIndex === 0 ? 'p1-card' : 'p2-card';
     const card = document.createElement('div');
-    card.className = `player ${player.isYou ? 'you' : ''} ${player.isReady ? 'ready' : ''} ${player.isOccupied ? '' : 'waiting'}`;
+    card.className = `player ${slotClass} ${player.isYou ? 'you' : ''} ${player.isReady ? 'ready' : ''} ${player.isOccupied ? '' : 'waiting'}`;
+    card.setAttribute('data-player', player.slotIndex);
+
+    const statusText = player.isOccupied
+      ? (player.isReserved ? 'Reserved' : player.isConnected ? 'Joined' : 'Disconnected')
+      : 'Waiting';
+    const readyBadgeClass = player.isReady ? 'is-ready' : 'not-ready';
+    const readyBadgeText = player.isReady ? '&#x2714; Ready' : '&#x25CB; Not ready';
+
     card.innerHTML = `
       <div class="player-meta">
         <strong>${player.displayName}${player.isYou ? ' (You)' : ''}</strong>
-        <span>${player.label} · ${player.isOccupied ? (player.isReserved ? 'Reserved' : player.isConnected ? 'Joined' : 'Disconnected') : 'Waiting'}</span>
+        <span class="player-label">${player.label}</span>
       </div>
-      <div class="player-state">${player.isOccupied ? (player.isReserved ? 'Reconnect window active' : player.isConnected ? (player.isReady ? 'Ready to launch' : 'Not ready yet') : 'Temporarily offline') : 'Open slot'}</div>
+      <div class="player-state">
+        <span class="player-ready-badge ${readyBadgeClass}">${readyBadgeText}</span>
+        <span class="player-status-text">${player.isOccupied ? (player.isReserved ? 'Reconnect window active' : player.isConnected ? (player.isReady ? 'Ready to launch' : 'Not ready yet') : 'Temporarily offline') : 'Open slot'}</span>
+      </div>
     `;
     playersEl.appendChild(card);
   }
 
+  // Update next-action copy based on lobby state
   const you = state.players.find((player) => player.isYou);
+  const opponent = state.players.find((player) => !player.isYou);
+  const opponentPresent = opponent && opponent.isOccupied;
+  const bothReady = state.allReady;
+  const bothPresent = state.allPlayersPresent;
+
+  if (!opponentPresent) {
+    nextActionIcon.textContent = '&#x1F4E3;';
+    nextActionText.textContent = 'Share the room code above and wait for your opponent to join.';
+  } else if (you && !you.isReady && opponent && !opponent.isReady) {
+    nextActionIcon.textContent = '&#x1F3C1;';
+    nextActionText.textContent = 'Both players are here! Hit "Ready" when you\'re set to go.';
+  } else if (you && !you.isReady) {
+    nextActionIcon.textContent = '&#x1F3C1;';
+    nextActionText.textContent = 'Your opponent is ready. Hit "Ready" to start the match!';
+  } else if (you && you.isReady && opponent && !opponent.isReady) {
+    nextActionIcon.textContent = '&#x23F3;';
+    nextActionText.textContent = 'You\'re ready! Waiting for your opponent to ready up.';
+  } else if (bothReady) {
+    nextActionIcon.textContent = '&#x1F680;';
+    nextActionText.textContent = 'Both ready — launching into the arena!';
+  }
+
+  if (nextActionArea) {
+    nextActionArea.classList.toggle('hidden', gameplayFocused);
+  }
+
+  // Both-ready indicator
+  if (bothReadyIndicator) {
+    bothReadyIndicator.classList.toggle('hidden', !bothReady || gameplayFocused);
+  }
+
   readyButton.textContent = you?.isReady ? 'Unready' : 'Ready up';
   readyButton.disabled = !you || !you.isOccupied || gameplayFocused;
   readyButton.classList.toggle('is-waiting', !!state.allPlayersPresent && !state.allReady);

--- a/public/index.html
+++ b/public/index.html
@@ -49,19 +49,52 @@
         </div>
 
         <div id="lobby" class="screen lobby hidden">
+          <div class="lobby-emblem" aria-hidden="true">
+            <div class="emblem-snake">
+              <svg viewBox="0 0 120 40" class="emblem-svg" aria-hidden="true">
+                <defs>
+                  <linearGradient id="snakeGrad" x1="0%" y1="0%" x2="100%" y2="0%">
+                    <stop offset="0%" stop-color="var(--p1-blue)" />
+                    <stop offset="100%" stop-color="var(--p2-orange)" />
+                  </linearGradient>
+                </defs>
+                <path d="M10 20 H30 Q36 20 36 14 V10 Q36 4 42 4 H78 Q84 4 84 10 V14 Q84 20 90 20 H110" fill="none" stroke="url(#snakeGrad)" stroke-width="3" stroke-linecap="round" />
+                <circle cx="110" cy="20" r="3" fill="var(--p2-orange)" />
+                <rect x="50" y="14" width="8" height="12" rx="2" fill="var(--accent-cyan)" opacity="0.7" />
+              </svg>
+            </div>
+            <h2 class="lobby-title">Snake Arena</h2>
+            <div class="scanline-accent" aria-hidden="true"></div>
+          </div>
+
           <div class="room-header room-code-hero">
-            <div>
+            <div class="room-code-column">
               <div class="eyebrow">Room code</div>
               <div id="roomCodeDisplay" class="room-code">----</div>
+              <p class="room-code-hint">Share this code with your opponent</p>
             </div>
-            <button id="copyRoomCodeButton" class="secondary-button" type="button">Copy</button>
+            <button id="copyRoomCodeButton" class="primary-button share-button" type="button">
+              <span class="share-icon">&#x1F4CB;</span> Share Code
+            </button>
           </div>
 
           <div class="lobby-meta-row">
             <div id="phaseBadge" class="badge status-chip">Lobby</div>
             <p id="lobbyMessage" class="message lobby-message"></p>
           </div>
+
           <div id="players" class="players"></div>
+
+          <div id="nextActionArea" class="next-action-area">
+            <div id="nextActionIcon" class="next-action-icon" aria-hidden="true"></div>
+            <p id="nextActionText" class="next-action-text"></p>
+          </div>
+
+          <div id="bothReadyIndicator" class="both-ready-indicator hidden" aria-live="polite">
+            <span class="both-ready-check">&#x2705;</span>
+            <span class="both-ready-text">Both players ready — launching!</span>
+          </div>
+
           <button id="readyButton" class="primary-button ready-button" type="button">Ready</button>
         </div>
 

--- a/public/styles.css
+++ b/public/styles.css
@@ -257,8 +257,204 @@ button:disabled { cursor: not-allowed; opacity: 0.58; }
 .player.you { border-color: rgba(46, 139, 255, 0.44); box-shadow: var(--glow-primary); }
 .player.ready { border-color: rgba(46, 139, 255, 0.32); }
 .player.waiting { opacity: 0.72; }
-.player-state { margin-top: 8px; }
+.player-state { margin-top: 8px; display: flex; align-items: center; gap: 8px; }
+.player-status-text {
+  font-size: 0.82rem;
+  color: var(--text-dim);
+  font-family: var(--font-mono);
+}
 .ready-button { min-height: 54px; }
+
+/* ═══ Lobby Clarity / Polish ═══ */
+
+/* ── Lobby Emblem ── */
+.lobby-emblem {
+  text-align: center;
+  padding: 16px 0 8px;
+  animation: emblemFadeIn 420ms var(--ease-arcade) both;
+  position: relative;
+}
+.emblem-snake {
+  display: flex;
+  justify-content: center;
+  margin-bottom: 4px;
+}
+.emblem-svg {
+  width: clamp(100px, 28vw, 160px);
+  height: auto;
+  filter: drop-shadow(0 0 10px rgba(46, 139, 255, 0.3));
+}
+.lobby-title {
+  font-family: var(--font-display);
+  font-size: clamp(1.1rem, 3vw, 1.5rem);
+  letter-spacing: 0.1em;
+  color: var(--text-primary);
+  margin: 0 0 4px;
+  text-shadow: 0 0 16px rgba(46, 139, 255, 0.25);
+}
+.scanline-accent {
+  width: min(100%, 240px);
+  height: 2px;
+  margin: 8px auto 0;
+  background: linear-gradient(90deg, transparent 0%, var(--p1-blue) 30%, var(--p2-orange) 70%, transparent 100%);
+  opacity: 0.5;
+  animation: scanlineSlide 3s ease-in-out infinite;
+}
+
+/* ── Room Code Hero (enhanced) ── */
+.room-code-column { display: grid; gap: 4px; }
+.room-code-hint {
+  margin: 0;
+  font-size: 0.78rem;
+  color: var(--text-dim);
+  font-family: var(--font-mono);
+  letter-spacing: 0.04em;
+}
+.room-code {
+  animation: roomCodePulse 2.4s ease-in-out infinite;
+}
+.share-button {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  white-space: nowrap;
+  background: linear-gradient(135deg, var(--accent-primary), #1a6fe6);
+}
+.share-icon { font-size: 1.1em; line-height: 1; }
+
+/* ── Lobby Player Cards (enhanced) ── */
+.player {
+  padding: 16px;
+  background: rgba(10, 18, 34, 0.9);
+  transition: border-color var(--motion-base) var(--ease-arcade), box-shadow var(--motion-base) var(--ease-arcade);
+}
+.player.p1-card {
+  border-left: 3px solid var(--p1-blue);
+  border-color: var(--p1-blue-glow);
+}
+.player.p2-card {
+  border-left: 3px solid var(--p2-orange);
+  border-color: var(--p2-orange-glow);
+}
+.player.p1-card.ready {
+  box-shadow: 0 0 0 1px var(--p1-blue-glow), 0 0 20px rgba(46, 139, 255, 0.15);
+}
+.player.p2-card.ready {
+  box-shadow: 0 0 0 1px var(--p2-orange-glow), 0 0 20px rgba(255, 122, 26, 0.15);
+}
+.player.you { border-color: rgba(46, 139, 255, 0.44); box-shadow: var(--glow-primary); }
+.player.ready { border-color: rgba(46, 139, 255, 0.32); }
+.player.waiting { opacity: 0.72; }
+.player-meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 10px;
+}
+.player-meta strong {
+  font-size: 1.05rem;
+}
+.player-meta .player-label {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--text-dim);
+}
+.player-state { margin-top: 8px; display: flex; align-items: center; gap: 8px; }
+.player-status-text {
+  font-size: 0.82rem;
+  color: var(--text-dim);
+  font-family: var(--font-mono);
+}
+.player-ready-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+}
+.player-ready-badge.is-ready {
+  background: rgba(135, 255, 181, 0.12);
+  border: 1px solid rgba(135, 255, 181, 0.32);
+  color: var(--accent-success);
+}
+.player-ready-badge.not-ready {
+  background: rgba(255, 209, 102, 0.10);
+  border: 1px solid rgba(255, 209, 102, 0.28);
+  color: var(--accent-warning);
+}
+
+/* Fade-in for lobby player cards */
+.players .player:nth-child(1) { animation: cardFadeIn 320ms var(--ease-arcade) both; }
+.players .player:nth-child(2) { animation: cardFadeIn 320ms var(--ease-arcade) 100ms both; }
+
+/* ── Next Action Area ── */
+.next-action-area {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 16px;
+  border-radius: var(--radius-md);
+  background: rgba(46, 139, 255, 0.06);
+  border: 1px solid rgba(46, 139, 255, 0.14);
+}
+.next-action-icon { font-size: 1.3rem; line-height: 1; }
+.next-action-text {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--text-muted);
+  font-family: var(--font-body);
+  line-height: 1.4;
+}
+
+/* ── Both Ready Indicator ── */
+.both-ready-indicator {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 14px 18px;
+  border-radius: var(--radius-md);
+  background: linear-gradient(135deg, rgba(135, 255, 181, 0.10), rgba(46, 139, 255, 0.08));
+  border: 1px solid rgba(135, 255, 181, 0.28);
+  animation: bothReadyPulse 1.6s ease-in-out infinite;
+}
+.both-ready-check { font-size: 1.2rem; }
+.both-ready-text {
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+  font-weight: 700;
+  color: var(--accent-success);
+  letter-spacing: 0.04em;
+}
+
+/* ── Lobby Animations ── */
+@keyframes roomCodePulse {
+  0%, 100% { opacity: 1; text-shadow: 0 0 8px rgba(46, 139, 255, 0.2); }
+  50% { opacity: 0.88; text-shadow: 0 0 20px rgba(46, 139, 255, 0.45), 0 0 40px rgba(46, 139, 255, 0.15); }
+}
+@keyframes emblemFadeIn {
+  from { opacity: 0; transform: translateY(-10px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+@keyframes scanlineSlide {
+  0%, 100% { transform: scaleX(0.6); opacity: 0.3; }
+  50% { transform: scaleX(1); opacity: 0.6; }
+}
+@keyframes cardFadeIn {
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+@keyframes bothReadyPulse {
+  0%, 100% { box-shadow: 0 0 0 0 rgba(135, 255, 181, 0); }
+  50% { box-shadow: 0 0 18px rgba(135, 255, 181, 0.18); }
+}
+
 .game { margin-top: 0; align-content: start; }
 .game-shell {
   display: grid;

--- a/scripts/verify-issue-99-screenshots.ts
+++ b/scripts/verify-issue-99-screenshots.ts
@@ -1,0 +1,172 @@
+// Verifier visual screenshot capture for issue #99 lobby clarity
+// Captures desktop and mobile lobby screens with both player counts.
+
+import { chromium } from '@playwright/test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+const BASE = process.env.E2E_BASE_URL || 'http://localhost:3100';
+const OUT_DIR = process.argv[2] || '/opt/data/.worktrees/t_6cd18933/verify-evidence';
+
+interface Metric { name: string; value: number | string; pass: boolean; }
+
+async function captureLobby(opts: {
+  viewport: { width: number; height: number };
+  label: string;
+  bringSecondPlayer?: boolean;
+}) {
+  const browser = await chromium.launch({ headless: true });
+  const ctx1 = await browser.newContext({ viewport: opts.viewport });
+  const page1 = await ctx1.newPage();
+  await page1.goto(BASE);
+  await page1.locator('#status').waitFor({ state: 'visible' });
+  await page1.locator('#playerNameInput').fill('Alice');
+  await page1.locator('#createRoomButton').click();
+  await page1.locator('#lobby').waitFor({ state: 'visible' });
+  const code = (await page1.locator('#roomCodeDisplay').textContent()) ?? '';
+
+  if (opts.bringSecondPlayer) {
+    const ctx2 = await browser.newContext({ viewport: opts.viewport });
+    const page2 = await ctx2.newPage();
+    await page2.goto(BASE);
+    await page2.locator('#status').waitFor({ state: 'visible' });
+    await page2.locator('#playerNameInput').fill('Bob');
+    await page2.locator('#roomCodeInput').fill(code);
+    await page2.locator('#joinRoomButton').click();
+    await page2.locator('#lobby').waitFor({ state: 'visible' });
+    await page1.waitForTimeout(600);
+  }
+
+  // Full-page screenshot of the lobby
+  const screenshotPath = path.join(OUT_DIR, `${opts.label}.png`);
+  await page1.screenshot({ path: screenshotPath, fullPage: true });
+
+  // Metrics
+  const metrics: Metric[] = [];
+
+  // Logo/emblem area exists
+  const emblemVisible = await page1.locator('.lobby-emblem').isVisible();
+  metrics.push({ name: 'emblem_visible', value: emblemVisible, pass: emblemVisible });
+
+  const svgVisible = await page1.locator('.emblem-svg').isVisible();
+  metrics.push({ name: 'emblem_svg_visible', value: svgVisible, pass: svgVisible });
+
+  const titleText = await page1.locator('.lobby-title').textContent();
+  metrics.push({ name: 'lobby_title_text', value: titleText ?? '', pass: (titleText ?? '').trim() === 'Snake Arena' });
+
+  // Room code prominent
+  const roomCodeText = await page1.locator('#roomCodeDisplay').textContent();
+  const roomCodeFontSize = await page1.locator('#roomCodeDisplay').evaluate(el => parseFloat(getComputedStyle(el).fontSize));
+  metrics.push({ name: 'room_code_text', value: roomCodeText ?? '', pass: !!(roomCodeText && roomCodeText !== '----') });
+  metrics.push({ name: 'room_code_font_size_px', value: roomCodeFontSize, pass: roomCodeFontSize >= 28 });
+
+  const roomCodeHeroVisible = await page1.locator('.room-code-hero').isVisible();
+  metrics.push({ name: 'room_code_hero_visible', value: roomCodeHeroVisible, pass: roomCodeHeroVisible });
+
+  // Share CTA present
+  const shareVisible = await page1.locator('#copyRoomCodeButton').isVisible();
+  const shareText = await page1.locator('#copyRoomCodeButton').textContent();
+  metrics.push({ name: 'share_button_visible', value: shareVisible, pass: shareVisible });
+  metrics.push({ name: 'share_button_text', value: shareText ?? '', pass: (shareText ?? '').toLowerCase().includes('share') });
+
+  // Player cards
+  const playerCount = await page1.locator('.player').count();
+  metrics.push({ name: 'player_card_count', value: playerCount, pass: playerCount === (opts.bringSecondPlayer ? 2 : 1) });
+
+  if (playerCount >= 1) {
+    const p1Badge = await page1.locator('.player.p1-card .player-ready-badge').first().textContent();
+    metrics.push({ name: 'p1_ready_badge', value: p1Badge ?? '', pass: !!(p1Badge && p1Badge.toLowerCase().includes('not ready')) });
+    const p1Border = await page1.locator('.player.p1-card').first().evaluate(el => getComputedStyle(el).borderLeftColor);
+    metrics.push({ name: 'p1_border_color', value: p1Border, pass: p1Border.includes('46, 139, 255') });
+  }
+
+  if (playerCount >= 2) {
+    const p2Badge = await page1.locator('.player.p2-card .player-ready-badge').first().textContent();
+    metrics.push({ name: 'p2_ready_badge', value: p2Badge ?? '', pass: !!(p2Badge && p2Badge.toLowerCase().includes('not ready')) });
+    const p2Border = await page1.locator('.player.p2-card').first().evaluate(el => getComputedStyle(el).borderLeftColor);
+    metrics.push({ name: 'p2_border_color', value: p2Border, pass: p2Border.includes('255, 122, 26') });
+  }
+
+  // Next-action copy present
+  const nextActionVisible = await page1.locator('#nextActionArea').isVisible();
+  const nextActionText = await page1.locator('#nextActionText').textContent();
+  metrics.push({ name: 'next_action_visible', value: nextActionVisible, pass: nextActionVisible });
+  metrics.push({ name: 'next_action_text', value: nextActionText ?? '', pass: !!(nextActionText && nextActionText.length > 0) });
+
+  // Regression guard: nextActionIcon must contain a real emoji glyph, not
+  // a raw HTML-entity literal like '&#x1F4E3;'. (Issue #99 follow-up.)
+  const nextActionIconText = (await page1.locator('#nextActionIcon').textContent()) ?? '';
+  const iconHasEntity = nextActionIconText.includes('&#x') || nextActionIconText.includes('&amp;');
+  const iconHasGrapheme = nextActionIconText.trim().length > 0;
+  metrics.push({ name: 'next_action_icon_text', value: JSON.stringify(nextActionIconText), pass: !iconHasEntity });
+  metrics.push({ name: 'next_action_icon_no_entity', value: !iconHasEntity, pass: !iconHasEntity });
+  metrics.push({ name: 'next_action_icon_has_grapheme', value: iconHasGrapheme, pass: iconHasGrapheme });
+
+  // CTAs differentiated
+  const readyText = await page1.locator('#readyButton').textContent();
+  metrics.push({ name: 'ready_button_text', value: readyText ?? '', pass: !!(readyText && readyText.toLowerCase().includes('ready')) });
+
+  const shareClass = await page1.locator('#copyRoomCodeButton').getAttribute('class');
+  const readyClass = await page1.locator('#readyButton').getAttribute('class');
+  metrics.push({ name: 'share_button_class', value: shareClass ?? '', pass: !!(shareClass && shareClass.includes('share-button')) });
+  metrics.push({ name: 'ready_button_class', value: readyClass ?? '', pass: !!(readyClass && readyClass.includes('ready-button')) });
+  metrics.push({ name: 'ctas_differentiated', value: shareClass !== readyClass, pass: shareClass !== readyClass });
+
+  // No clipping — body scrollWidth <= clientWidth
+  const scrollW = await page1.locator('body').evaluate(el => el.scrollWidth);
+  const clientW = await page1.locator('body').evaluate(el => el.clientWidth);
+  metrics.push({ name: 'no_horizontal_overflow', value: `${scrollW}<=${clientW}`, pass: scrollW <= clientW + 2 });
+
+  // Lobby element fully visible
+  const lobbyBox = await page1.locator('#lobby').boundingBox();
+  metrics.push({ name: 'lobby_bbox', value: JSON.stringify(lobbyBox), pass: !!lobbyBox && lobbyBox.height > 200 });
+
+  await browser.close();
+  return { screenshotPath, metrics };
+}
+
+(async () => {
+  fs.mkdirSync(OUT_DIR, { recursive: true });
+  const results: any[] = [];
+
+  for (const scenario of [
+    { viewport: { width: 1280, height: 800 }, label: 'desktop-solo', bringSecondPlayer: false },
+    { viewport: { width: 1280, height: 800 }, label: 'desktop-duo', bringSecondPlayer: true },
+    { viewport: { width: 390, height: 844 }, label: 'mobile-solo', bringSecondPlayer: false },
+    { viewport: { width: 390, height: 844 }, label: 'mobile-duo', bringSecondPlayer: true },
+  ]) {
+    try {
+      const r = await captureLobby(scenario);
+      results.push({ scenario: scenario.label, ...r });
+    } catch (err: any) {
+      results.push({ scenario: scenario.label, error: err.message });
+    }
+  }
+
+  // Write report
+  const reportLines: string[] = [];
+  reportLines.push('# Issue #99 Lobby Clarity — Verifier Visual Evidence');
+  reportLines.push('');
+  for (const r of results) {
+    reportLines.push(`## Scenario: ${r.scenario}`);
+    if (r.error) {
+      reportLines.push(`- ERROR: ${r.error}`);
+    } else {
+      reportLines.push(`- Screenshot: ${r.screenshotPath}`);
+      const failed = r.metrics.filter((m: Metric) => !m.pass);
+      const passed = r.metrics.filter((m: Metric) => m.pass);
+      reportLines.push(`- Passed: ${passed.length}/${r.metrics.length}`);
+      for (const m of r.metrics) {
+        const mark = m.pass ? '✓' : '✗';
+        reportLines.push(`  - ${mark} ${m.name}: ${m.value}`);
+      }
+      if (failed.length) {
+        reportLines.push(`- FAILED metrics: ${failed.map((f: Metric) => f.name).join(', ')}`);
+      }
+    }
+    reportLines.push('');
+  }
+  const reportPath = path.join(OUT_DIR, 'report.md');
+  fs.writeFileSync(reportPath, reportLines.join('\n'));
+  console.log(reportLines.join('\n'));
+})();

--- a/tests/e2e/lobby-clarity.spec.ts
+++ b/tests/e2e/lobby-clarity.spec.ts
@@ -79,6 +79,27 @@ test.describe('Lobby clarity — waiting state', () => {
     await expect(guidanceText).toContainText('Share');
   });
 
+  test('next-action icon renders a real emoji glyph (no raw HTML entity)', async ({ page }) => {
+    // Regression guard for issue #99 follow-up: the nextActionIcon was being
+    // set with `textContent = '&#x1F4E3;'` which renders as literal text in a
+    // real browser. The icon must contain a single non-empty grapheme that
+    // does NOT include the raw `&#x` HTML-entity prefix.
+    const icon = page.locator('#nextActionIcon');
+    await expect(icon).toBeVisible();
+
+    const text = (await icon.textContent()) ?? '';
+    expect(text).not.toContain('&#x');
+    expect(text).not.toContain('&amp;');
+    // Should be a non-empty, non-whitespace single grapheme (emoji).
+    expect(text.trim().length).toBeGreaterThan(0);
+    // The waiting-state icon is the megaphone (📣 = U+1F4E3). It is encoded
+    // as a surrogate pair in JS strings, so the length is 2 — but the
+    // character count (codepoints) is 1.
+    const codepoints = Array.from(text);
+    expect(codepoints.length).toBeGreaterThanOrEqual(1);
+    expect(codepoints.join('').trim()).toBe('\u{1F4E3}');
+  });
+
   test('Share code button is visible', async ({ page }) => {
     const shareBtn = page.locator('#copyRoomCodeButton');
     await expect(shareBtn).toBeVisible();
@@ -147,6 +168,13 @@ test.describe('Lobby clarity — both players present', () => {
     await page1.waitForTimeout(500);
     const guidanceP1 = await page1.locator('#nextActionText').textContent() ?? '';
     expect(guidanceP1).toMatch(/Ready|both/i);
+
+    // Regression guard for issue #99 follow-up: the nextActionIcon on the
+    // both-present state must render a real checkered-flag glyph (🏁 = U+1F3C1),
+    // not a raw `&#x1F3C1;` HTML-entity literal.
+    const iconP1 = (await page1.locator('#nextActionIcon').textContent()) ?? '';
+    expect(iconP1).not.toContain('&#x');
+    expect(Array.from(iconP1.trim()).join('')).toBe('\u{1F3C1}');
 
     // Both should see 2 player cards
     const cardsP1 = await page1.locator('.player').count();

--- a/tests/e2e/lobby-clarity.spec.ts
+++ b/tests/e2e/lobby-clarity.spec.ts
@@ -1,0 +1,169 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Lobby clarity / polish — issue #99
+ *
+ * Verifies the lobby UI presents:
+ *  - Emblem / logo area
+ *  - Prominent room code with pulse animation
+ *  - Player cards with P1/P2 colour coding and ready badges
+ *  - "What happens next" guidance copy (next-action area)
+ *  - Share / Ready CTAs
+ *  - Subtle animation classes (pulse, fade-in)
+ *  - Mobile-friendly (no horizontal overflow)
+ */
+
+test.describe('Lobby clarity — waiting state', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    // Wait until socket connects
+    await expect(page.locator('#status')).not.toHaveText('Connecting…', { timeout: 10_000 });
+
+    // Enter a player name and create a room
+    await page.locator('#playerNameInput').fill('Tester');
+    await page.locator('#createRoomButton').click();
+
+    // Lobby should become visible
+    await expect(page.locator('#lobby')).toBeVisible({ timeout: 8_000 });
+  });
+
+  test('emblem zone renders with title', async ({ page }) => {
+    const emblem = page.locator('.lobby-emblem');
+    await expect(emblem).toBeVisible();
+
+    // Title text
+    await expect(page.locator('.lobby-title')).toHaveText('Snake Arena');
+  });
+
+  test('room code is the most prominent element', async ({ page }) => {
+    const roomCodeEl = page.locator('#roomCodeDisplay');
+    await expect(roomCodeEl).toBeVisible();
+    await expect(roomCodeEl).not.toHaveText('----');
+
+    // Room code font-size should be at least 1.8rem (clamp lower bound)
+    const fontSize = await roomCodeEl.evaluate((el) =>
+      parseFloat(getComputedStyle(el).fontSize),
+    );
+    expect(fontSize).toBeGreaterThanOrEqual(28); // 1.8rem ≈ 28.8px
+
+    // Room code hero section has glow
+    const hero = page.locator('.room-code-hero');
+    await expect(hero).toBeVisible();
+  });
+
+  test('player card for P1 has blue left-border accent', async ({ page }) => {
+    const p1Card = page.locator('.player.p1-card');
+    await expect(p1Card).toBeVisible();
+
+    // Check border-left includes P1 blue (#2E8BFF → rgb(46, 139, 255))
+    const borderLeft = await p1Card.evaluate((el) =>
+      getComputedStyle(el).borderLeftColor,
+    );
+    // border-left-color should be the P1 blue
+    expect(borderLeft).toContain('46, 139, 255');
+  });
+
+  test('player card shows ready badge', async ({ page }) => {
+    const badge = page.locator('.player-ready-badge');
+    await expect(badge.first()).toBeVisible();
+
+    // New player is not ready yet
+    await expect(badge.first()).toHaveClass(/not-ready/);
+  });
+
+  test('guidance copy: "Share" when waiting for opponent', async ({ page }) => {
+    const nextAction = page.locator('#nextActionArea');
+    await expect(nextAction).toBeVisible();
+
+    const guidanceText = page.locator('#nextActionText');
+    await expect(guidanceText).toContainText('Share');
+  });
+
+  test('Share code button is visible', async ({ page }) => {
+    const shareBtn = page.locator('#copyRoomCodeButton');
+    await expect(shareBtn).toBeVisible();
+    await expect(shareBtn).toContainText('Share');
+  });
+
+  test('Ready button present and enabled', async ({ page }) => {
+    const readyBtn = page.locator('#readyButton');
+    await expect(readyBtn).toBeVisible();
+    await expect(readyBtn).toBeEnabled();
+    await expect(readyBtn).toHaveText('Ready up');
+  });
+
+  test('player cards have fade-in animation', async ({ page }) => {
+    // Check that animation CSS is applied (cardFadeIn keyframes)
+    const p1Card = page.locator('.player.p1-card');
+    const animation = await p1Card.evaluate((el) =>
+      getComputedStyle(el).animationName,
+    );
+    expect(animation).toContain('cardFadeIn');
+  });
+
+  test('room code has pulse animation', async ({ page }) => {
+    const roomCodeEl = page.locator('#roomCodeDisplay');
+    const animation = await roomCodeEl.evaluate((el) =>
+      getComputedStyle(el).animationName,
+    );
+    expect(animation).toContain('roomCodePulse');
+  });
+
+  test('lobby is responsive — no horizontal overflow', async ({ page }) => {
+    // Set mobile viewport
+    await page.setViewportSize({ width: 375, height: 812 });
+    await page.waitForTimeout(300);
+
+    const body = page.locator('body');
+    const scrollWidth = await body.evaluate((el) => el.scrollWidth);
+    const clientWidth = await body.evaluate((el) => el.clientWidth);
+    expect(scrollWidth).toBeLessThanOrEqual(clientWidth + 2); // 2px tolerance
+  });
+});
+
+test.describe('Lobby clarity — both players present', () => {
+  test('guidance changes when both players are in the room', async ({ browser }) => {
+    // Player 1 creates a room
+    const ctx1 = await browser.newContext();
+    const page1 = await ctx1.newPage();
+    await page1.goto('/');
+    await expect(page1.locator('#status')).not.toHaveText('Connecting…', { timeout: 10_000 });
+    await page1.locator('#playerNameInput').fill('Alice');
+    await page1.locator('#createRoomButton').click();
+    await expect(page1.locator('#lobby')).toBeVisible({ timeout: 8_000 });
+    const code = (await page1.locator('#roomCodeDisplay').textContent()) ?? '';
+
+    // Player 2 joins the same room
+    const ctx2 = await browser.newContext();
+    const page2 = await ctx2.newPage();
+    await page2.goto('/');
+    await expect(page2.locator('#status')).not.toHaveText('Connecting…', { timeout: 10_000 });
+    await page2.locator('#playerNameInput').fill('Bob');
+    await page2.locator('#roomCodeInput').fill(code);
+    await page2.locator('#joinRoomButton').click();
+    await expect(page2.locator('#lobby')).toBeVisible({ timeout: 8_000 });
+
+    // Player 1 should now see guidance about both players being present
+    await page1.waitForTimeout(500);
+    const guidanceP1 = await page1.locator('#nextActionText').textContent() ?? '';
+    expect(guidanceP1).toMatch(/Ready|both/i);
+
+    // Both should see 2 player cards
+    const cardsP1 = await page1.locator('.player').count();
+    expect(cardsP1).toBe(2);
+
+    const cardsP2 = await page2.locator('.player').count();
+    expect(cardsP2).toBe(2);
+
+    // P2 card should have orange accent
+    const p2Card = page1.locator('.player.p2-card');
+    await expect(p2Card).toBeVisible();
+    const borderLeft = await p2Card.evaluate((el) =>
+      getComputedStyle(el).borderLeftColor,
+    );
+    expect(borderLeft).toContain('255, 122, 26');
+
+    await ctx1.close();
+    await ctx2.close();
+  });
+});


### PR DESCRIPTION
## Summary

Lobby polish for issue #99 — players should immediately know **who is here**, **what to do next**, and **how the match starts**, with a stronger retro-arcade brand.

### What's new

- **Emblem / logo zone** with SVG snake logo and "Snake Arena" title
- **Room code promoted** to the most prominent element (pulse animation, eyebrow label, copy hint)
- **P1 / P2 player cards** with blue/orange accent borders, ready badges, fade-in
- **State-dependent "next action" guidance copy** with proper emoji icons:
  - waiting: 📣 Share the room code…
  - both present, neither ready: 🏁 Both players are here! Hit "Ready"…
  - opponent ready, you not: 🏁 Your opponent is ready. Hit "Ready"…
  - you ready, opponent not: ⏳ You're ready! Waiting for your opponent…
  - both ready: 🚀 Both ready — launching into the arena!
- **Share Code CTA** replaces plain Copy button (blue gradient + 📋)
- **Both-ready indicator** with pulse animation
- **Scanline accent** and **fade-in / pulse** subtle decorations
- **No horizontal overflow** on mobile (375px + 390px verified)

### Tests

- `npm run build` (tsc) clean
- `npm test` (vitest) 30/30 pass
- `npx playwright test` 21/21 pass (was 19, +2 icon-regression assertions)
- Desktop (1280×800) + mobile (390×844) screenshots captured for both solo and duo states
- No regressions on issue #150 co-op wall-layout safety or issue #154 board bounds

### Files

- `public/index.html` — lobby markup
- `public/app.js` — `renderLobby()` state handling
- `public/styles.css` — lobby design system
- `tests/e2e/lobby-clarity.spec.ts` — 13 new Playwright assertions (lobby states, icon regression guard, both-present icon guard)
- `scripts/verify-issue-99-screenshots.ts` — verifier screenshot+metrics script (extended with `next_action_icon_text` / `_no_entity` / `_has_grapheme` metrics)

### Acceptance criteria

- [x] Lobby is visually cleaner, with stronger retro-arcade branding
- [x] Proper logo/emblem area exists in the lobby
- [x] Room code is prominent and easy to read
- [x] Player names + ready state are clearly visible and ordered
- [x] Next-action copy is unambiguous
- [x] "Share / Ready / Both ready" CTAs are clearly differentiated
- [x] Subtle lobby animation / decorative elements present
- [x] No changes to game logic or server protocol
- [x] Build/tests/E2E green; live verify confirms clarity on desktop + mobile
- [x] No regression on the issue #150 wall safety and #154 board bounds checks

### Follow-up fix included in this branch

The verifier (t_6cd18933) caught a regression: `nextActionIcon.textContent = '&#x1F4E3;'` does **not** parse HTML entities, so the browser rendered literal entity text. This PR includes the fix (commit `8e23443`) switching all 5 lines to `String.fromCodePoint(0x...)` plus two e2e regression guards and three new verifier-screenshot metrics. The new tests fail (red) when the bug is reintroduced — confirmed by direct mutation test.

### Visual evidence

- `/opt/data/.worktrees/t_6cd18933/verify-evidence/fix-desktop-solo.png` — 📣 megaphone on solo waiting
- `/opt/data/.worktrees/t_6cd18933/verify-evidence/fix-desktop-duo.png` — 🏁 checkered flag on both-present
- `/opt/data/.worktrees/t_6cd18933/verify-evidence/fix-mobile-solo.png` — 📣 megaphone on mobile
- `/opt/data/.worktrees/t_6cd18933/verify-evidence/fix-mobile-duo.png` — 🏁 checkered flag on mobile
- `/opt/data/.worktrees/t_6cd18933/verify-evidence/fix-report.md` — verifier metrics report (icon metrics all green)

Closes #99